### PR TITLE
fix: limit uvicorn reload scope to package directory

### DIFF
--- a/src/mlx_omni_server/main.py
+++ b/src/mlx_omni_server/main.py
@@ -1,4 +1,6 @@
+import argparse
 import logging
+import os
 
 import uvicorn
 from fastapi import FastAPI
@@ -19,5 +21,42 @@ app.add_middleware(
 app.include_router(api_router)
 
 
+def build_parser():
+    """Create and configure the argument parser for the server."""
+    parser = argparse.ArgumentParser(description="MLX Omni Server")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind the server to, defaults to 0.0.0.0",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=10240,
+        help="Port to bind the server to, defaults to 10240",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload on code changes, defaults to False",
+    )
+    return parser
+
+
 def start():
-    uvicorn.run("mlx_omni_server.main:app", host="0.0.0.0", port=10240, reload=True)
+    """Start the MLX Omni Server."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Get the package directory for default reload path
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Start server with uvicorn
+    uvicorn.run(
+        "mlx_omni_server.main:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        reload_dirs=[package_dir] if args.reload else None,
+    )


### PR DESCRIPTION
## Description
Fixed the issue where uvicorn's auto-reload feature was scanning system directories by limiting the reload scope to only the package directory.

## Changes
- Added `reload_dirs` configuration to uvicorn
- Set default reload directory to package directory when `--reload` is enabled
- Updated help messages for command line arguments

Fixes #1