### PR TITLE
Adding v1/embeddings endpoint using mlx-embeddings

### DIFF
--- a/examples/embeddings.ipynb
+++ b/examples/embeddings.ipynb
@@ -1,0 +1,375 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "01c4198a",
+   "metadata": {},
+   "source": [
+    "# MLX Omni Server: Embeddings API Example\n",
+    "\n",
+    "This notebook demonstrates how to use the OpenAI-compatible Embeddings API endpoint with MLX Omni Server.\n",
+    "\n",
+    "With MLX Omni Server, you can generate embeddings locally on your Apple Silicon device using a variety of models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29536289",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, let's import the OpenAI client and configure it to use our local MLX Omni Server instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f721cccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "import numpy as np\n",
+    "from sklearn.metrics.pairwise import cosine_similarity\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Configure client to use local server\n",
+    "client = OpenAI(\n",
+    "    base_url=\"http://localhost:10240/v1\",  # Point to local server\n",
+    "    api_key=\"not-needed\",  # API key is not required for local server\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43f5b561",
+   "metadata": {},
+   "source": [
+    "## Generate Embeddings for a Single Text\n",
+    "\n",
+    "Let's start by generating embeddings for a single piece of text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "db22f01f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Response type: <class 'openai.types.create_embedding_response.CreateEmbeddingResponse'>\n",
+      "Model used: mlx-community/all-MiniLM-L6-v2-4bit\n",
+      "Embedding dimension: 384\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate embedding for a single text\n",
+    "response = client.embeddings.create(\n",
+    "    model=\"mlx-community/all-MiniLM-L6-v2-4bit\", input=\"I like reading\"\n",
+    ")\n",
+    "\n",
+    "# Examine the response structure\n",
+    "print(f\"Response type: {type(response)}\")\n",
+    "print(f\"Model used: {response.model}\")\n",
+    "print(f\"Embedding dimension: {len(response.data[0].embedding)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03c7b451",
+   "metadata": {},
+   "source": [
+    "## v1/chat/embeddings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f26f7bfc",
+   "metadata": {},
+   "source": [
+    "### Testing Embeddings API with Curl\n",
+    "\n",
+    "You can directly test the embeddings endpoint using curl, as follows:\n",
+    "\n",
+    "```shell\n",
+    "curl http://localhost:10240/v1/embeddings \\\n",
+    "  -H \"Content-Type: application/json\" \\\n",
+    "  -d '{\n",
+    "    \"model\": \"mlx-community/all-MiniLM-L6-v2-4bit\",\n",
+    "    \"input\": [\"Hello world!\", \"Embeddings are useful for semantic search.\"]\n",
+    "  }'\n",
+    "```\n",
+    "\n",
+    "This will return a JSON response with the embeddings for each input text."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "445b582d",
+   "metadata": {},
+   "source": [
+    "### Visualize a Few Dimensions of the Embedding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b0069afe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2IAAAE8CAYAAACitAI8AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAANBpJREFUeJzt3Qd0VNX6//8nIRCKJPQSigFRCNLrBVFQuHQV5YsE4VKFn0oV5BqQIiAEpEi/Ea+gfC9IsSJovAgiXAgtFAEBQaUTAiKEcg0l+a9nf9fMfyZMQsrkTCbzfq11VnLOnDmzZ+YE5jN77+f4JScnJwsAAAAAwDL+1j0UAAAAAEARxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAPi0EydOiJ+fn3z44Yfiq0JDQ6V379729U2bNpnXRH/mtufmraKjo6VOnTqSP39+895cuXIlw8fQ+w0aNEhyi7feess8p0uXLmX7Y7Vo0cIs9+Pqb0fPPz0PASAlghiAXE0Dln4wcrVERERky2NOmTJFvvjii3Tv/49//EO6dOkiFStWNO1KKzjoB/ABAwZIyZIlpVChQvLkk0/Knj173NRy5ES///67vPDCC1KgQAFZsGCB/O///q95713Ztm2bCSiZCWoAAGsFWPx4AOAREydOlEqVKjltq1Gjhjz44IPy3//+V/LmzevWIPY///M/0qlTp3TtP23aNLl27Zo0atRIzp8/n+p+SUlJ0qFDB9m/f7+MHDlSSpQoIQsXLjTf1MfGxsrDDz/slvY/8cQT5jXJly+feLujR4+Kv793f+e4a9cuc35MmjRJWrVqlea+GsQmTJhgwnyRIkUsayNS9/7775u/XQBIiSAGwCe0a9dOGjRo4PI2He51Pzdu3Ei1FyKrfvjhB3tv2AMPPJDqfp988on5oL169WoT9JT2lDzyyCMyfvx4Wb58uVvao8ElPa+JNwgMDBRvFx8fb34SrLyTO7/kAZC7ePfXhACQDXPEtDdBA9Evv/wi7du3l8KFC0v37t3NbceOHZPOnTtLmTJlTFgpX768hIeHy9WrV83teiwNbR999JF9COT95ihpr5zudz8axEqXLi3PP/+8fZsOUdQw9uWXX0piYmKa909OTpa3337btLlgwYJmWOOhQ4fSNc9Fe920B/HHH3+U5s2bm/tXqVLFtMkWJhs3bmyGz1WtWlW+++67e4579uxZ6du3r3kOGpAeffRRWbx4scvHXrVqlUyePNm0VV/nli1byvHjx532vd97kdocsV9//dUMBS1WrJh5Hn/5y19k3bp12dqO1Giorl+/vnndtIezR48e5nVyfN179eplfm/YsGGa55MOSdSeUqW9v7bzT89xRzpsVt9L23ug888y816l5V//+pf9eenrrK/H6dOnnfZxxzmldI6Y/g0EBQVJ8eLFZejQofLnn39mqk1q0aJF8tBDD5n9tJd6y5YtLh/3zJkzptdbv6ApVaqUvPbaay7/BlPOEbP9mzNjxgz7Y+lrrO+v9n66OkeqV69uzi19vT7//HPmnQG5BD1iAHyCfihOOalfP/im5s6dO9KmTRtp1qyZ+cCkHxJv3bpltumHrcGDB5sP3vqBde3atWZOTnBwsJm/89JLL5kPcDqXS+kHLXfYu3ev1KtX756hdvpY+oHu559/lpo1a6Z6/3HjxpkgpuFSF51b1rp1a/O80uOPP/6Qjh07mg+wGmR0bpv+vmzZMhk2bJi8/PLL8uKLL8r06dNNj51+yNUQqy5cuGACj61ghAbIb775Rvr16ycJCQnm/o6mTp1qnufrr79u3rt33nnHhOEdO3aY29PzXrii7WjatKncvHlThgwZYj64a2h+5plnTAB47rnnLGmH0vDfp08f8wE8MjLStG3OnDmydetW815rD9ibb75pQoi+v7bhtamdTxrQ9Rz4+OOP5d1337Wf3/pa2/znP/+Rzz77TF599VXz3sydO9eEyFOnTpnXIjPvVUoaXMeOHWvCkf4tXLx4UebNm2eGvNqelzvOKRt9HA0l+hpu377dPCc97tKlSzPcpg8++ED+3//7f+Yc0cfX0K7nhga3ChUq2I+nQ3c1lOvrpudRSEiI+dvfuHGjpJf2YOuQU308fa313NL3UB/T1oumXxB07drV/F3r89Pnpe9DuXLl0v04AHKwZADIxZYsWZKs/9S5WtRvv/1mftf9bHr16mW2RUREOB1r7969Zvvq1avTfMxChQqZY2RGWvfV2/r27XvP9nXr1pl2RUdHp3rc+Pj45Hz58iV36NAhOSkpyb599OjR5r6Oj/n999+bbfrTpnnz5mbb8uXL7duOHDlitvn7+ydv377dvv3bb7+95zXt169fctmyZZMvXbrk1K7w8PDk4ODg5Js3bzo9dlhYWHJiYqJ9vzlz5pjtBw4cyNB78eCDDzo9t2HDhpn7bdmyxb7t2rVryZUqVUoODQ1Nvnv3bra0I6Vbt24llypVKrlGjRrJ//3vf+3b165da443bty4e87hXbt23fe406dPN/vqeZ2Sbtdz4Pjx4/Zt+/fvN9vnzZuX4ffKlRMnTiTnyZMnefLkyU7b9fUKCAhw2p7Vc2r8+PFm2zPPPOP0WK+++qrZrs8tI22yvSd16tRxes8XLVpkjqfttZk9e7bZtmrVKvu2GzduJFepUuWevx09//Q8tLH9m1O8ePHky5cv27d/+eWXZvtXX31l31azZs3k8uXLm3PUZtOmTWY/x2MC8E4MTQTgE7Ta3Pr1652W+3nllVec1m29G99++63pUbGafgvvas6TbT6X3p4aHdalvTfaa+M4DPJ+vRuOdLim9lbYaE+N9iSEhYWZIWQ2tt/1m32lGeDTTz+Vp59+2vyuPZO2RXuTtKcpZeVH7SlyLBby+OOPOx0zs+/F119/bXoQtafT8Xlp76UOGfvpp58sacfu3bvN3C/tmXKcj6fFWKpVq3bPUEl30WIfjj1qtWrVMkP6svJeOdLeNi1MoT1PjvfVnkItJvP999+75ZxyNHDgQKd1Pcdt73VG2mR7T7QXzvE912GAKXs29dhly5a1z9VU2mtu6wVPD+3pKlq0aKrn1rlz5+TAgQPSs2dPp7mjOowzrZ5vAN6DoYkAfIJ++E6tWIcrAQEBZq6PIx0WNnz4cJk1a5YZOqUfnHTYks7rSWsImrvonBVXc1Bs82H09tScPHnS/ExZWVGHnTl+GEyLvh4p57Lp83YcsmXbpnQYldJhYDpMT4fX6ZJWQQobLV7iyNZG2zEz+17o6+D4Ad9GP/jbbtd5OFa0wxY8UtIgpkMIs0PK52N7Tll5r1LOl9MAl1oFz5SFKzJ7TjlK+VgaNHU4qW1uXHrblNrfiN5euXJlp226r85nS9l2V+9nau53btnao4+Tkm7jshWA9yOIAYAL2vPkquz5zJkzzTfkWhzj3//+t5kfYpubkjK4uZt+A++qvL1tm85TyU558uTJ0Pb/Gw33f2X3lYYTW+GJlLRnJiPHtOq9yCntcJfseK8c6f01nOicMlePlbIqaGbPqbSkDEcZbZNVsvIcAeQOBDEAyCAdFqTLmDFjTDn5xx57TKKiokwhDJWeCoiZUadOHVPBTT9YOoZELRyhw6K0jH1alRltvQOO3+5rD4irXgZ30l43LbBw9+7d+14Hy93vhavXQa8tltKRI0fst1vVDqVteeqpp5xu022ZbUdWz72svlfaG6VBQnsK0zof3UnPacdrBGpVS/0bsVUVTG+bHP9GHN+T27dvy2+//Sa1a9d22vfgwYPmuI6vuatzK7Ns7UlZpTO1bQC8D3PEACCdtGKcVlN0pB++NRQ5DhnUctY6vMvddD6KVrTTOS82OtdFy1vrnJ60rpmlH6p1iJVWinP8xn327NlixTf/WplP5x7ph9eUNAxm13uRklaL3Llzp8TExNi36eUGdBiefnDXMuFWtEOHyWrJcw1rjvtpr83hw4fNXLHMsF3rLrPnX1bfK636p8fQi0qn7NnR9d9//12yY/6nIz3HbdcOzEib9D3RIKrviWMlUa1umfL11PNI53DZSu0rnSOY2nDOzNAebh0mq9Ufr1+/bt+uZf117hgA70ePGACkk5am1nLeWmZbv1nXD+Bastr24dVGr1WkxTF03pB+mNJv4l3NS7L56quvZP/+/fZv3/W6SraeFJ1vZBsKpkFMy4prAQktKqHlyRcuXGh6L/RDZlr0A6aWYNchc1ouXD9Iatlu/eCfVhl/d9Ey8FoUQV+H/v37m8Bz+fJlM89FXyv9PTvei5QiIiJMeXf9kK5DCLUsuZav1x4PDR+uhqNmRzs0FE+bNs28l1p8oVu3bvby9RoI9ZpUmaHnntKy91oEQx9HQ3pGLkaelfdKe5/03B01apSZo6XX2dIeNn199fpXWsxCz0N30mPr30nbtm1NwNbrhWnJe1sPVnrbpK+V7qfl5LVHTItp6D5Lliy5Z46Yvi7z5883hTRiY2PNsGF937Vn2p2mTJkizz77rOlh1XNFe6/1cTWgOYYzAN6JIAYA6aQf7LRynAYnvVaUfujSbRpmNCDZaADTD3c6TE0rGepcm7SCmAYADQM2GpB0UTrHyBbE9MO9VmvTi/bqtZL02HoNKv3GPj1FAvRDplbo02/8bR+0dU5TZntfMkIvDKw9UXotLO3R0wCp163SCwVrIMmu98JVO3To4BtvvGF6TrTQib6+epzMvA6ZbYfSeWW6vwYfbY+GJb2Omb4ejtfaygg9HyZNmmTeY71Qsw7R0zCRkSCW1fdKw66GUr2Wme0LAi2+odes08DkbitXrjTXyNPH1SI7Goz1umOZaZP+3eoXG3p//TvT3s01a9aYa5A50vdtw4YNpkKjnke6rteX04CvgdBdNETrFwd6sW59DlpIRP/e9d8LVxdjB+Bd/LSGvacbAQAAgPTPF9Ve7vRchgNAzsUcMQAAgBxIhyqnnIO4adMmM5S5RYsWHmsXAPegRwwAACAH0jltWmhHLyeg8021uqcOO9XrqmkxFR0yCsB7MUcMAAAgB9KLPGsBln/+85+mYqXO9dO5jDqvkBAGeD96xAAAAADAYswRAwAAAACLEcQAAAAAwGLMEXMDvU7LuXPnzAUi/fz8PN0cAAAAAB6iM7+uXbtmiuz4+6fe70UQcwMNYXphSAAAAABQp0+flvLly0tqCGJuoD1hthc7KCjI080BAAAA4CEJCQmmk8aWEVJDEHMD23BEDWEEMQAAAAB+95myRLEOAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAi3EdMQAAAHi10Ih14gtOTO3g6SbAjegRAwAAAACL0SMGAACQw9HjA+Q+9IgBAAAAgMXoEQMAwAL0aAAAHNEjBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFjM64LYggULJDQ0VPLnzy+NGzeWnTt3prrvoUOHpHPnzmZ/Pz8/mT17dpaPCQAAAAA+FcRWrlwpw4cPl/Hjx8uePXukdu3a0qZNG4mPj3e5/82bN6Vy5coydepUKVOmjFuOCQAAAAA+FcRmzZol/fv3lz59+kj16tUlKipKChYsKIsXL3a5f8OGDWX69OkSHh4ugYGBbjkmAAAAAPhMELt165bExsZKq1at7Nv8/f3NekxMjKXHTExMlISEBKcFAAAAAHJdELt06ZLcvXtXSpcu7bRd1+Pi4iw9ZmRkpAQHB9uXChUqZOrxAQAAAPgmrwliOcmoUaPk6tWr9uX06dOebhIAAAAALxIgXqJEiRKSJ08euXDhgtN2XU+tEEd2HVPnm6U25wwAAAAAck2PWL58+aR+/fqyYcMG+7akpCSz3qRJkxxzTAAAAADINT1iSsvM9+rVSxo0aCCNGjUy1wW7ceOGqXioevbsKeXKlTNzuGzFOH766Sf772fPnpV9+/bJAw88IFWqVEnXMQEAAADAp4NY165d5eLFizJu3DhTTKNOnToSHR1tL7Zx6tQpU/XQ5ty5c1K3bl37+owZM8zSvHlz2bRpU7qOCQAAAAA+HcTUoEGDzOKKLVzZhIaGSnJycpaOCQAAAAA+O0cMAAAAAHILghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFvC6ILViwQEJDQyV//vzSuHFj2blzZ5r7r169WqpVq2b2r1mzpnz99ddOt/fu3Vv8/PyclrZt22bzswAAAADgy7wqiK1cuVKGDx8u48ePlz179kjt2rWlTZs2Eh8f73L/bdu2Sbdu3aRfv36yd+9e6dSpk1kOHjzotJ8Gr/Pnz9uXjz/+2KJnBAAAAMAXeVUQmzVrlvTv31/69Okj1atXl6ioKClYsKAsXrzY5f5z5swxIWvkyJESFhYmkyZNknr16sn8+fOd9gsMDJQyZcrYl6JFi1r0jAAAAAD4Iq8JYrdu3ZLY2Fhp1aqVfZu/v79Zj4mJcXkf3e64v9IetJT7b9q0SUqVKiVVq1aVV155RX7//fc025KYmCgJCQlOCwAAAADkuiB26dIluXv3rpQuXdppu67HxcW5vI9uv9/+2mO2dOlS2bBhg0ybNk1++OEHadeunXms1ERGRkpwcLB9qVChQpafHwAAAADfESA+Ljw83P67FvOoVauWPPTQQ6aXrGXLli7vM2rUKDNXzUZ7xAhjAAAAAHJdj1iJEiUkT548cuHCBaftuq7zulzR7RnZX1WuXNk81vHjx1PdR+eUBQUFOS0AAAAAkOuCWL58+aR+/fpmCKFNUlKSWW/SpInL++h2x/3V+vXrU91fnTlzxswRK1u2rBtbDwAAAABeGMSUDgd8//335aOPPpLDhw+bwho3btwwVRRVz549zbBBm6FDh0p0dLTMnDlTjhw5Im+99Zbs3r1bBg0aZG6/fv26qai4fft2OXHihAltzz77rFSpUsUU9QAAAAAA8fU5Yl27dpWLFy/KuHHjTMGNOnXqmKBlK8hx6tQpU0nRpmnTprJ8+XIZM2aMjB49Wh5++GH54osvpEaNGuZ2Her4448/mmB35coVCQkJkdatW5sy9zr8EAAAAADE14OY0t4sW49WSlpgI6UuXbqYxZUCBQrIt99+6/Y2AgAAAECuGZoIAAAAALkBQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsFeLoBcL/QiHWS252Y2sHTTQAAAAAyjR4xAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiXhfEFixYIKGhoZI/f35p3Lix7Ny5M839V69eLdWqVTP716xZU77++mun25OTk2XcuHFStmxZKVCggLRq1UqOHTuWzc8CAAAAgC/zqiC2cuVKGT58uIwfP1727NkjtWvXljZt2kh8fLzL/bdt2ybdunWTfv36yd69e6VTp05mOXjwoH2fd955R+bOnStRUVGyY8cOKVSokDnmn3/+aeEzAwAAAOBLvCqIzZo1S/r37y99+vSR6tWrm/BUsGBBWbx4scv958yZI23btpWRI0dKWFiYTJo0SerVqyfz58+394bNnj1bxowZI88++6zUqlVLli5dKufOnZMvvvjC4mcHAAAAwFd4TRC7deuWxMbGmqGDNv7+/mY9JibG5X10u+P+Snu7bPv/9ttvEhcX57RPcHCwGfKY2jFVYmKiJCQkOC0AAAAAkF4B4iUuXbokd+/eldKlSztt1/UjR464vI+GLFf763bb7bZtqe3jSmRkpEyYMEFyqhNTO3i6CTlaaMQ6ye2ycg7w+qSN18e3X5usvD7825w2zp/suZ+v4PVJmy/8fZ3wwnPAa3rEcpJRo0bJ1atX7cvp06c93SQAAAAAXsRrgliJEiUkT548cuHCBaftul6mTBmX99Htae1v+5mRY6rAwEAJCgpyWgAAAAAg1wWxfPnySf369WXDhg32bUlJSWa9SZMmLu+j2x33V+vXr7fvX6lSJRO4HPfR+V5aPTG1YwIAAACAz8wRU1q6vlevXtKgQQNp1KiRqXh448YNU0VR9ezZU8qVK2fmcKmhQ4dK8+bNZebMmdKhQwdZsWKF7N69WxYtWmRu9/Pzk2HDhsnbb78tDz/8sAlmY8eOlZCQEFPmHgAAAADE14NY165d5eLFi+YCzFpMo06dOhIdHW0vtnHq1ClTSdGmadOmsnz5clOefvTo0SZsaVn6GjVq2Pf5+9//bsLcgAED5MqVK9KsWTNzTL0ANAAAAACIrwcxNWjQILO4smnTpnu2denSxSyp0V6xiRMnmgUAAAAArOA1c8QAAAAAILcgiAEAAACAxbxuaCKA7OWNF0QEAADwNvSIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAAN4QxO7cuSPfffedvPfee3Lt2jWz7dy5c3L9+nV3tw8AAAAAcp0MV008efKktG3bVk6dOiWJiYny17/+VQoXLizTpk0z61FRUdnTUgAAAADw1R6xoUOHSoMGDeSPP/6QAgUK2Lc/99xzsmHDBne3DwAAAABynQz3iG3ZskW2bdsm+fLlc9oeGhoqZ8+edWfbAAAAACBXynCPWFJSkty9e/ee7WfOnDFDFAEAAAAAbg5irVu3ltmzZ9vX/fz8TJGO8ePHS/v27TN6OAAAAADwORkemjhz5kxp06aNVK9eXf7880958cUX5dixY1KiRAn5+OOPs6eVAAAAAODLQax8+fKyf/9+WbFihfz444+mN6xfv37SvXt3p+IdAAAAAAA3BTFzp4AA6dGjR2buCgAAAAA+L8NBbOnSpWne3rNnz6y0BwAAAAByvYDMXEfM0e3bt+XmzZumnH3BggUJYgAAAADg7qqJeiFnx0XniB09elSaNWtGsQ4AAAAAyI4g5srDDz8sU6dOvae3DAAAAACQTUHMVsDj3Llzkl0uX75sKjMGBQVJkSJFTKVG7Y1Li5bXHzhwoBQvXlweeOAB6dy5s1y4cMFpH70OWspFK0ICAAAAQI6ZI7ZmzRqn9eTkZDl//rzMnz9fHnvsMckuGsL0cdavX2/mpfXp00cGDBggy5cvT/U+r732mqxbt05Wr14twcHBMmjQIHn++edl69atTvstWbJE2rZta1/XoAcAAAAAOSaIderUyWlde5BKliwpTz31lLnYc3Y4fPiwREdHy65du6RBgwZm27x586R9+/YyY8YMCQkJuec+V69elQ8++MAENW2bLXCFhYXJ9u3b5S9/+YtT8CpTpky2tB0AfMWJqR083QQAAHLv0MSkpCSn5e7duxIXF2cCT9myZbOlkTExMSYs2UKYatWqlfj7+8uOHTtc3ic2Ntb0nOl+NtWqVZOKFSua4znS4YslSpSQRo0ayeLFi00vX1oSExMlISHBaQEAAACAbL2gs9U06JUqVeqeOWnFihUzt6V2Hy2pn3KYYenSpZ3uM3HiRNNjpqX3//3vf8urr75q5p4NGTIk1fZERkbKhAkTsvy8AAAAAPimdAWx4cOHp/uAs2bNSve+ERERMm3atPsOS8xOY8eOtf9et25duXHjhkyfPj3NIDZq1Cin10R7xCpUqJCt7QQAAADgY0Fs79696TqYzhfLiBEjRkjv3r3T3Kdy5cpm/lZ8fLzT9jt37phKiqnN7dLtt27dkitXrjj1imnVxLTmgzVu3FgmTZpkhh8GBga63Ee3p3YbAAAAALgliH3//feSHbTIhy7306RJExOodN5X/fr1zbaNGzeaOWoanFzR/fLmzSsbNmwwZeuVXnj61KlT5nip2bdvnxQtWpSgBQAAAMC354hppUMtL9+/f3+JiooyRTi0FH14eLi9YuLZs2elZcuWsnTpUlN0Q8vV67XGdAihziXT648NHjzYhDBbxcSvvvrK9JDpev78+U1p/ClTpsjrr7/u4WcMAAAAuAdVbXNRENu9e7esWrXK9C7p8D9Hn332mWSHZcuWmfClYUurJWov19y5c+23azjTHq+bN2/at7377rv2fXWoYZs2bWThwoX227XHbMGCBeZ6Y1opsUqVKmaOmwY+AAAAAMgxQWzFihXSs2dPE2q0ymDr1q3l559/Nj1Lzz33XPa0UsT0aqV18ebQ0NB7ys5rL5cGLV1c0V42xws5AwAAAECOvI6YDt3TniYd1qfl4efMmSNHjhyRF154wVyjCwAAAADg5iD2yy+/SIcO/zfOVIOYlnvXaok6vG/RokUZPRwAAAAA+JwMBzGtKHjt2jXze7ly5eTgwYPmd61q6Dg/CwAAAACQxSBmC1xPPPGEqS6ounTpIkOHDjXFLbp162YKaQAAAAAA3FSso1atWtKwYUPp1KmTCWDqzTffNJUHt23bZioTjhkzJr2HAwAAAACfle4g9sMPP8iSJUskMjJSJk+ebILXSy+9JBEREdnbQgAAAADw1aGJjz/+uCxevFjOnz8v8+bNkxMnTkjz5s3lkUcekWnTpklcXFz2thQAAAAAfLVYR6FChaRPnz6mh0yvH6bDFPU6XVq6/plnnsmeVgIAAACALwcxR1WqVJHRo0ebuWGFCxeWdevWua9lAAAAAODrc8RS2rx5sxmq+Omnn4q/v7+5oHO/fv3c2zoAAAAA8PUgdu7cOfnwww/Ncvz4cWnatKnMnTvXhDAdsggAAAAAcGMQa9eunXz33XdSokQJ6dmzp/Tt21eqVq2a3rsDOcaJqR083QQAAAD4uHQHMb1e2CeffCIdO3aUPHnyZG+rAAAAACAXS3cQW7NmTfa2BAAAAAB8RJaqJgIAAAAAMo4gBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFvOaIHb58mXp3r27BAUFSZEiRaRfv35y/fr1NO+zaNEiadGihbmPn5+fXLlyxS3HBQAAAACfCGIalg4dOiTr16+XtWvXyubNm2XAgAFp3ufmzZvStm1bGT16tFuPCwAAAACWXNDZkw4fPizR0dGya9cuadCggdk2b948ad++vcyYMUNCQkJc3m/YsGHm56ZNm9x6XAAAAADI9T1iMTExZtigLSypVq1aib+/v+zYscPy4yYmJkpCQoLTAgAAAAC5KojFxcVJqVKlnLYFBARIsWLFzG1WHzcyMlKCg4PtS4UKFTLdBgAAAAC+x6NBLCIiwhTRSGs5cuSI5DSjRo2Sq1ev2pfTp097ukkAAAAAvIhH54iNGDFCevfuneY+lStXljJlykh8fLzT9jt37piKh3pbZmX2uIGBgWYBAAAAAK8LYiVLljTL/TRp0sSUno+NjZX69eubbRs3bpSkpCRp3Lhxph8/u44LAAAAAF4/RywsLMyUoe/fv7/s3LlTtm7dKoMGDZLw8HB7ZcOzZ89KtWrVzO02Os9r3759cvz4cbN+4MABs649Xuk9LgAAAAD4ZBBTy5YtM0GrZcuWprx8s2bNzAWbbW7fvi1Hjx411w6ziYqKkrp165qgpZ544gmzvmbNmnQfFwAAAADczS85OTnZ7Uf1MVq+XqsnauGOoKAgTzcHQDYKjVgnud2JqR083QT4IF/421L8fQG5X0I6s4HX9IgBAAAAQG5BEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAB86YLOAOBtqHgGAADcgR4xAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLeU0Qu3z5snTv3l2CgoKkSJEi0q9fP7l+/Xqa91m0aJG0aNHC3MfPz0+uXLlyzz6hoaHmNsdl6tSp2fhMAAAAAPg6rwliGsIOHTok69evl7Vr18rmzZtlwIABad7n5s2b0rZtWxk9enSa+02cOFHOnz9vXwYPHuzm1gMAAADA/y9AvMDhw4clOjpadu3aJQ0aNDDb5s2bJ+3bt5cZM2ZISEiIy/sNGzbM/Ny0aVOaxy9cuLCUKVMmG1oOAAAAAF7aIxYTE2OGI9pCmGrVqpX4+/vLjh07snx8HYpYvHhxqVu3rkyfPl3u3LmT5v6JiYmSkJDgtAAAAABAruoRi4uLk1KlSjltCwgIkGLFipnbsmLIkCFSr149c6xt27bJqFGjzPDEWbNmpXqfyMhImTBhQpYeFwAAAIDv8miPWERExD2FMlIuR44cydY2DB8+3BT0qFWrlrz88ssyc+ZMM+xRe71So2Ht6tWr9uX06dPZ2kYAAAAAuYtHe8RGjBghvXv3TnOfypUrm/lb8fHxTtt1+KBWUnT33K7GjRubY584cUKqVq3qcp/AwECzAAAAAIDXBbGSJUua5X6aNGliSs/HxsZK/fr1zbaNGzdKUlKSCU7utG/fPjP3LOVQSAAAAADwqTliYWFhpgx9//79JSoqSm7fvi2DBg2S8PBwe8XEs2fPSsuWLWXp0qXSqFEjs03nj+ly/Phxs37gwAFTIbFixYpmTpgWAdFiH08++aTZruuvvfaa9OjRQ4oWLerR5wwAAAAg9/KKqolq2bJlUq1aNRO2tGx9s2bNzAWbbTScHT161Fw7zEZDm1ZC1ACnnnjiCbO+Zs0as67DC1esWCHNmzeXRx99VCZPnmyCmONxAQAAAMDd/JKTk5PdflQfo+Xrg4ODTeGOoKAgTzcHAACvExqxTnzBiakdPN0EADkkG3hNjxgAAAAA5BYEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIt5TRC7fPmydO/eXYKCgqRIkSLSr18/uX79epr7Dx48WKpWrSoFChSQihUrypAhQ+Tq1atO+506dUo6dOggBQsWlFKlSsnIkSPlzp07FjwjAAAAAL4qQLyEhrDz58/L+vXr5fbt29KnTx8ZMGCALF++3OX+586dM8uMGTOkevXqcvLkSXn55ZfNtk8++cTsc/fuXRPCypQpI9u2bTPH79mzp+TNm1emTJli8TMEAAAA4Cv8kpOTkyWHO3z4sAlTu3btkgYNGpht0dHR0r59ezlz5oyEhISk6zirV6+WHj16yI0bNyQgIEC++eYb6dixowlnpUuXNvtERUXJG2+8IRcvXpR8+fKl67gJCQkSHBxsetu0xw4AAGRMaMQ68QUnpnbwdBMAZLP0ZgOvGJoYExNjhiPaQphq1aqV+Pv7y44dO9J9HNuLoSHMdtyaNWvaQ5hq06aNefEOHTqU6nESExPNPo4LAAAAAKSXVwSxuLg4M3/LkYapYsWKmdvS49KlSzJp0iQznNHxuI4hTNnW0zpuZGSkSbm2pUKFChl8RgAAAAB8mUeDWEREhPj5+aW5HDlyJMuPoz1WOhdMhze+9dZbWT7eqFGjTO+abTl9+nSWjwkAAADAd3i0WMeIESOkd+/eae5TuXJlU0wjPj7eabtWNtTKiHpbWq5duyZt27aVwoULy+eff24KcdjofXfu3Om0/4ULF+y3pSYwMNAsAAAAAOB1QaxkyZJmuZ8mTZrIlStXJDY2VurXr2+2bdy4UZKSkqRx48Zp9oTpnC8NTWvWrJH8+fPfc9zJkyebkGcb+qhVGXUemfaeAQAAAIDPzhELCwszvVr9+/c3PVhbt26VQYMGSXh4uL1i4tmzZ6VatWr2Hi4NYa1btzYVEj/44AOzrvO+dNGy9Upv18D1t7/9Tfbv3y/ffvutjBkzRgYOHEiPFwAAAIBs4zXXEVu2bJkJXy1btjTVEjt37ixz5861367XFjt69KjcvHnTrO/Zs8deUbFKlSpOx/rtt98kNDRU8uTJI2vXrpVXXnnF9I4VKlRIevXqJRMnTrT42QEAAADwJV5xHbGcjuuIAQCQNVxHDEBukauuIwYAAAAAuQlBDAAAAAAsRhADAAAAAIt5TbEOAACQezF3CoCvoUcMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALBZg9QPmRsnJyeZnQkKCp5sCAAAAwINsmcCWEVJDEHODa9eumZ8VKlTwdFMAAAAA5JCMEBwcnOrtfsn3i2q4r6SkJDl37pwULlxY/Pz8xBdTv4bQ06dPS1BQkKebAy/CuYOs4PxBVnD+ICs4f5AWjVcawkJCQsTfP/WZYPSIuYG+wOXLlxdfp/8Q8Y8RMoNzB1nB+YOs4PxBVnD+IDVp9YTZUKwDAAAAACxGEAMAAAAAixHEkGWBgYEyfvx48xPICM4dZAXnD7KC8wdZwfkDd6BYBwAAAABYjB4xAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMWTJggULJDQ0VPLnzy+NGzeWnTt3erpJ8AKRkZHSsGFDKVy4sJQqVUo6deokR48e9XSz4KWmTp0qfn5+MmzYME83BV7i7Nmz0qNHDylevLgUKFBAatasKbt37/Z0s5DD3b17V8aOHSuVKlUy581DDz0kkyZNEureIbMIYsi0lStXyvDhw0351j179kjt2rWlTZs2Eh8f7+mmIYf74YcfZODAgbJ9+3ZZv3693L59W1q3bi03btzwdNPgZXbt2iXvvfee1KpVy9NNgZf4448/5LHHHpO8efPKN998Iz/99JPMnDlTihYt6ummIYebNm2a/OMf/5D58+fL4cOHzfo777wj8+bN83TT4KUoX49M0x4w7dXQf5BUUlKSVKhQQQYPHiwRERGebh68yMWLF03PmAa0J554wtPNgZe4fv261KtXTxYuXChvv/221KlTR2bPnu3pZiGH0/+ftm7dKlu2bPF0U+BlOnbsKKVLl5YPPvjAvq1z586md+xf//qXR9sG70SPGDLl1q1bEhsbK61atbJv8/f3N+sxMTEebRu8z9WrV83PYsWKebop8CLaq9qhQwenf4eA+1mzZo00aNBAunTpYr4Aqlu3rrz//vuebha8QNOmTWXDhg3y888/m/X9+/fLf/7zH2nXrp2nmwYvFeDpBsA7Xbp0yYyV1m+GHOn6kSNHPNYueB/tSdW5PTpUqEaNGp5uDrzEihUrzJBoHZoIZMSvv/5qhpfp0PrRo0ebc2jIkCGSL18+6dWrl6ebhxzem5qQkCDVqlWTPHnymM9BkydPlu7du3u6afBSBDEAHu/VOHjwoPlWEUiP06dPy9ChQ838Qi0UBGT0yx/tEZsyZYpZ1x4x/TcoKiqKIIY0rVq1SpYtWybLly+XRx99VPbt22e+SAwJCeHcQaYQxJApJUqUMN8GXbhwwWm7rpcpU8Zj7YJ3GTRokKxdu1Y2b94s5cuX93Rz4CV0WLQWBdL5YTb6zbSeRzpnNTEx0fz7BLhStmxZqV69utO2sLAw+fTTTz3WJniHkSNHml6x8PBws67VNk+ePGkqARPEkBnMEUOm6BCO+vXrm7HSjt8y6nqTJk082jbkfFojSEPY559/Lhs3bjSlgIH0atmypRw4cMB8G21btIdDhwfp74QwpEWHQae8XIbO+XnwwQc91iZ4h5s3b5r58I703xv9/ANkBj1iyDQdX6/fAOkHoEaNGplqZVp+vE+fPp5uGrxgOKIO7fjyyy/NtcTi4uLM9uDgYFN9CkiLnjMp5xMWKlTIXBOKeYa4n9dee80UXdChiS+88IK5/uWiRYvMAqTl6aefNnPCKlasaIYm7t27V2bNmiV9+/b1dNPgpShfjyzRYUDTp083H6S1dPTcuXNNWXsgLXrxXVeWLFkivXv3trw98H4tWrSgfD3STYdEjxo1So4dO2Z65PWLxf79+3u6Wcjhrl27Zi7orKM5dHi0zg3r1q2bjBs3zowUAjKKIAYAAAAAFmOOGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAMAn+Pn5yRdffCE52aZNm0w7r1y54ummAACyGUEMAODVevfubcKLLnnz5pXSpUvLX//6V1m8eLEkJSXZ9zt//ry0a9dOcrKmTZuadgYHB3u6KQCAbEYQAwB4vbZt25oAc+LECfnmm2/kySeflKFDh0rHjh3lzp07Zp8yZcpIYGCg5GT58uUz7dRQCQDI3QhiAACvpwFLA0y5cuWkXr16Mnr0aPnyyy9NKPvwww/vGZqogU3XV61aJY8//rgUKFBAGjZsKD///LPs2rVLGjRoIA888IDpQbt48aLTY/3zn/+UsLAwyZ8/v1SrVk0WLlxov8123M8++8yEwYIFC0rt2rUlJibGvs/Jkyfl6aeflqJFi0qhQoXk0Ucfla+//jrVoYmffvqp2UefY2hoqMycOdOpPbptypQp0rdvXylcuLBUrFhRFi1alE2vNADAXQhiAIBc6amnnjIhSENRasaPHy9jxoyRPXv2SEBAgLz44ovy97//XebMmSNbtmyR48ePy7hx4+z7L1u2zKxPnjxZDh8+bALQ2LFj5aOPPnI67ptvvimvv/667Nu3Tx555BHp1q2bvWdu4MCBkpiYKJs3b5YDBw7ItGnTTOhzJTY2Vl544QUJDw83+7711lvm8Wzh0kbDmYbHvXv3yquvviqvvPKKHD16NIuvIAAgOwVk69EBAPAg7bH68ccfU71dw1KbNm3M7zqUUQPThg0b5LHHHjPb+vXr5xR6NLhp6Hn++efNeqVKleSnn36S9957T3r16uV03A4dOpjfJ0yYYHq0NNRpe06dOiWdO3eWmjVrmtsrV66cavtmzZolLVu2NOFLaajTx5s+fbqZG2fTvn17E8DUG2+8Ie+++658//33UrVq1Uy+cgCA7EaPGAAg10pOTk5zvlWtWrXsv2uRD2ULSLZt8fHx5vcbN27IL7/8YsKZ9mDZlrfffttsT+24ZcuWNT9txxkyZIi5j4Y9DXZpBUXtdbOFQhtdP3bsmNy9e9fl4+nz1WGatscDAORMBDEAQK6lQUZ7rVKjVRZtbIEt5TZb5cXr16+bn++//74ZcmhbDh48KNu3b7/vcW3Heemll+TXX3+Vv/3tb2a4oQ4pnDdvXpaep+PjpWw3ACBnIogBAHKljRs3mqCjwwDdQXvHQkJCTIiqUqWK05JW2HOlQoUK8vLLL5v5ayNGjDDhzhUtCrJ161anbbquQxTz5MmTpecDAPAs5ogBALyeFr+Ii4szw/UuXLgg0dHREhkZacrX9+zZ022Po/O9dGihXudLS+br4+7evVv++OMPGT58eLqOMWzYMFONUcOU3k/ncmngckVDmlZznDRpknTt2tVUX5w/f75TpUYAgHciiAEAvJ4GL52LpZUPtSy8VkucO3euKaDh7+++wR86rFBL0muxjJEjR5ry8zqnTMNVemlY1MqJZ86ckaCgIBPotLiGK1qKX0vsa6VGDWP6HCdOnOhUqAMA4J38knUmMwAAAADAMswRAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAABBr/X8y5KGy4qIkCwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualize first 10 dimensions of the embedding\n",
+    "embedding = response.data[0].embedding[:10]\n",
+    "plt.figure(figsize=(10, 3))\n",
+    "plt.bar(range(len(embedding)), embedding)\n",
+    "plt.title(\"First 10 dimensions of the embedding\")\n",
+    "plt.xlabel(\"Dimension\")\n",
+    "plt.ylabel(\"Value\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e3c9321",
+   "metadata": {},
+   "source": [
+    "## Generate Embeddings for Multiple Texts\n",
+    "\n",
+    "The API can efficiently generate embeddings for multiple texts in a single request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7237fd2e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 4 embeddings of dimension 384\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Multiple texts to embed\n",
+    "texts = [\n",
+    "    \"I like reading fiction books.\",\n",
+    "    \"The weather is nice today.\",\n",
+    "    \"Neural networks are a type of machine learning model.\",\n",
+    "    \"I enjoy reading science books.\",\n",
+    "]\n",
+    "\n",
+    "# Generate embeddings for multiple texts\n",
+    "response = client.embeddings.create(\n",
+    "    model=\"mlx-community/all-MiniLM-L6-v2-4bit\", input=texts\n",
+    ")\n",
+    "\n",
+    "# Create a list of embeddings\n",
+    "embeddings = [item.embedding for item in response.data]\n",
+    "print(f\"Generated {len(embeddings)} embeddings of dimension {len(embeddings[0])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84585c4d",
+   "metadata": {},
+   "source": [
+    "## Semantic Search Example\n",
+    "\n",
+    "One of the most common uses of embeddings is semantic search. Let's demonstrate a simple example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0d278726",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Text</th>\n",
+       "      <th>Similarity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>I like reading fiction books.</td>\n",
+       "      <td>0.916941</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>I enjoy reading science books.</td>\n",
+       "      <td>0.815611</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Neural networks are a type of machine learning...</td>\n",
+       "      <td>0.781193</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>The weather is nice today.</td>\n",
+       "      <td>0.759635</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                Text  Similarity\n",
+       "0                      I like reading fiction books.    0.916941\n",
+       "3                     I enjoy reading science books.    0.815611\n",
+       "2  Neural networks are a type of machine learning...    0.781193\n",
+       "1                         The weather is nice today.    0.759635"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Convert embeddings to numpy arrays for easier manipulation\n",
+    "embeddings_np = np.array(embeddings)\n",
+    "\n",
+    "# Generate embedding for a query\n",
+    "query = \"I love to read books\"\n",
+    "query_response = client.embeddings.create(\n",
+    "    model=\"mlx-community/all-MiniLM-L6-v2-4bit\", input=query\n",
+    ")\n",
+    "query_embedding = np.array(query_response.data[0].embedding)\n",
+    "\n",
+    "# Calculate cosine similarity between the query and all texts\n",
+    "similarities = cosine_similarity([query_embedding], embeddings_np)[0]\n",
+    "\n",
+    "# Create a DataFrame to display results\n",
+    "results = pd.DataFrame({\"Text\": texts, \"Similarity\": similarities})\n",
+    "\n",
+    "# Sort by similarity (highest first)\n",
+    "results = results.sort_values(\"Similarity\", ascending=False)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdda2e9e",
+   "metadata": {},
+   "source": [
+    "## Text Clustering Example\n",
+    "\n",
+    "Let's try clustering similar texts using their embeddings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ce04f362",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArQAAAJOCAYAAABGN5SlAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAbZxJREFUeJzt3Ql8VNX5//HvZE8gC4EshEVARBZlEQRRKFqoCGpdW7QqiopLa13QKm6ApWp/Wi3ua931p3X51br8RUFRURTZRDaVfQ0hQBKyJzPzf50TM2TIBEK4M8kkn3dft8ncuXNyJ4eJzzzznOe6vF6vVwAAAECYimjsEwAAAAAOBQEtAAAAwhoBLQAAAMIaAS0AAADCGgEtAAAAwhoBLQAAAMIaAS0AAADCGgEtAAAAwhoBLQAAAMIaAS2AQ9alSxddcskljo7pcrk0bdo03+0XXnjB7lu/fr2jP+fEE0+0W0tl5s3MHwCEMwJaoJGY4Kw+25w5cxz5eVu3brUB4pIlS+r9mB9++EHnnnuuDjvsMMXFxalDhw76zW9+o0ceeUTNVUN+T/VhxjTzGRERoU2bNtW6v6CgQPHx8faYa6655qDHLy4utj/DqX8vABBOohr7BICW6uWXX/a7/dJLL+mTTz6ptb9Xr16OBWp33XWXzcb179//gMd//fXXOumkk9S5c2dNnDhRmZmZNhD75ptv9NBDD+nPf/6z79gff/zRBmpOKikpUVRU8P9Effzxx4f0ezpYsbGx+t///V/dfPPNfvvfeeedQxrXBLTmvI2DyTg/88wz8ng8h/SzAaCxEdACjeTCCy/0u20CRRPQ7ru/sdx9991KTk7Wd999p5SUFL/7cnJyagVpTjMZ4WAyAWBCQoJiYmIUSmPHjg0Y0L722ms69dRT9fbbb4fkPIqKitSqVStFR0eH5OcBQDBRcgA0YSZzNmPGDPXp08cGeBkZGbryyiu1e/du3zFTp0612dHZs2f7PfaKK66wwdr3339vP4Y+9thj7f4JEyb4yhlMXWpd1qxZY3/uvsGskZ6evt8a2up617lz5+raa69VWlqaHcece3l5ufLy8jR+/Hi1adPGbia483q9+62hDeTdd9+1QWBWVpYNqg8//HBNnz5dbrfb7ziTsTzqqKO0cOFC/epXv7KB7G233ea7rzqjub/fk/k9m+Bvx44dtc7D/K7N8ystLdWB/OEPf7DlDKtWrfLty87O1qeffmrv25f5fU2ZMkUDBw60bzBMEDp8+HB99tlnvmNMXbH5HRsmS1t93tW/PzM3rVu3tnNqAurExERdcMEFAWto6/PvCQCaGgJaoAkzAeBf/vIXnXDCCfZjfhNkvfrqqxo9erQqKirsMXfccYf9aPyyyy7Tnj177L6ZM2faj5JNINSvXz9btvDXv/7VF5iYsgazmeCuLqZu1gSAy5Yta/D5m7KEn3/+2QZZv/3tb/X000/rzjvv1Omnn26DznvuuUfDhg3T/fffX6vUoj5MoGkCtUmTJtnfjwn6zHOePHlyrWN37typMWPG2N+VeZNgyin2tb/f00UXXaTKykq98cYbtQLOt956S+ecc069sspmrI4dO9qMbDUzpnkeJjgPVFv77LPP2qD7f/7nf2yQaoJq82+gus7XBLNPPPGE/f6ss87ynffZZ5/tG8ecu3mMeTPyj3/8w55vIPX59wQATY4XQJPwpz/9yaQofbe//PJLe/vVV1/1O+6jjz6qtf+HH37wxsTEeC+//HLv7t27vR06dPAOGjTIW1FR4Tvmu+++s497/vnn63U+H3/8sTcyMtJuQ4cO9d58883emTNnesvLy2sde9hhh3kvvvhi323zM8zPGj16tNfj8fj2m3FcLpf3qquu8u2rrKz0duzY0TtixAi/Mc3jp06dWmvMdevW+fYVFxfXOpcrr7zSm5CQ4C0tLfXtM2Obxz755JO1jjf31fzZ+/s9mfMfMmSI37533nnHHv/ZZ59598c8F3Pcjh07vDfddJO3e/fuvvuOPfZY74QJE3zP2/xbqPn7KSsr8xvLzHFGRob30ksv9e0z4+77O6tm5sbcN3ny5ID3mfmrqT7/ngCgKSFDCzRRb775pv2I2XQVyM3N9W0mC2myeTU/cjYfp5ssqMnkmSycOe7FF188pEVV5ufOmzfPZlbNx8z33XefHdt0Ovjvf/9brzFMls989F1tyJAhtrTA7K8WGRmpQYMGae3atQd9jqYrQDWTTTTP23wcb+pja36kb5iSBJPhPhSmTOLbb7+1H91XMxnzTp06acSIEfUex5QWrF692tYnV38NVG5Q/fuprvM1JSi7du2y2VbzO1u0aNFBnf/VV19dr+OC8e8JAIKJgBZoosxH9fn5+fYjYvORcs2tsLCw1sIsU5pgPg6eP3++rYPs3bv3IZ+DqSc1q+9Nza4Z99Zbb7WBo2nltWLFigM+3nRIqMkE6IYJAPfdX7MuuL6WL19uP2I3j09KSrK/m+pFdeZ3V5MJxA91Adi4ceNsYGyC2Oqf8f7779t61JqB+4EMGDBAPXv2tGUHZizTQeLXv/51ncebYLJv3762pKFt27b2eX7wwQe1nuP+mGDUlDrUVzD+PQFAsPB2G2iiTDbOBLPVwdO+qhcBVTMZThMEV/ePdZIJBE1wa7YePXrYTKfJIJtAZ39MdrG++/ddFHYgZmGZyYqaQNbUvZoFYSbgM1nLW265pVYrqprZ3IYyC9hOO+00OyemntTUzpaVlTWoM4XJyJq6V7NAywTKdbU9e+WVV+zCrTPPPNMGmebfhPn93XvvvX6Z4gMxgfjBtFYL5r8nAHAaAS3QRJkAbdasWXZB2IGCMRO8maDHBHfXX3+9XWxlsqg1FwUdTAZxf8xH3ca2bdvUmExHArPQy2SQay5uW7du3SGNe6Dfkyk7OOOMM2yZgAlsTbbVdINoSEBrgmLze9zfgjgTNHfr1s0+z5rntu+bCafmt77/ngCgKaHkAGiifv/739tOAKYN1b5MDaXJUFZ78MEH7YUQTBcBc/zxxx9v6yVN7WM10+7JqPm4/TE1uoGyph9++KH9euSRR6oxVWd5a56j6Tjw+OOPH9K4B/o9mU4J7dq1sx0HPv/88wb3DTZvWEy3BZNpHTx48EE9T1PHa+qbazKtyPZ33gejPv+eAKApIUMLNFHm43TTtssEPKY908knn2z7oJqPgc3H/aZNlcmarVy50rbCMhk10w6rup2Vab30xz/+Uf/+9799AZTplfrkk0/aj7lN4GYWaXXt2rXOlltmcZWpUTX1niZYNEGOaTFl+pYe6gKrQ2WCLFMCcPHFF9tetyZDaTKdB1u6sK8D/Z7MHJx33nl69NFHbbB5/vnnN/hnXXfddQc8xpQ4mOysmQfT1stkoM25mZpWU0tdzWTxzT4zP6YsJDU11S7uMtvBqO+/JwBoSsjQAk2YCVxMlswsADMXAjCLskwDfpMVNKUIJoNrAjqTMTTZvmpHHHGEDYRN4FsdgJhAzCwuMkHYVVddZQMxk2Gsi+lVanq1moys6fNqNrNAyAQ1JkMY6IILoWQWR5kFWe3bt7e9U835ms4MphvDoajP78mUHRgjR460Pz+YTGBpPvI3nSZM4G56wpq62urSj5pMVwKz+O2GG26w523KFQ7Gwfx7AoCmxGV6dzX2SQBAODHBpclYvvTSS/aCCwCAxkWGFgAOkrlqlukFzCIpAGgaqKEFgHp67733bP9dUwZyzTXX+BaQAQAaFyUHAFBPZjHc9u3b7dWzzAI0s2gMAND4KDkAgHpav369SkpK9J///IdgFkBY+OKLL2zHkqysLNsNxvz9qk+f72OOOcZekKV79+6208m+HnvsMfsm31zQxnSCMYuGGxMBLQAAQDNVVFRkL2NtAtD6MK0BTYtA0+XGtIw0F1e5/PLLbYeVaqY9oOl8Yy7wYq7OaMY3n1zte0n2UKLkAAAAoAVwuVz6v//7P3sp7bqYS4d/8MEHWrZsmW+f6b1tLtry0Ucf2dsmI2suhW76cVdfXbBTp062f/nkyZPVGFrcojDzS9+6dav9uNDJS0UCAIDQMLm4PXv22I/RIyKa1ofNpaWl9kI0wXzu+8YvsbGxdnOCuQrhqFGj/PaZ7KvJ1BrmuS1cuND2Ra9m5sA8Zt8rGIZSiwtoTTBr3kUAAIDwtmnTJnXs2FFNKZjtelhrZee4g/YzTMvAmlcJNKZOnapp06Y5Mn52drYyMjL89pnbBQUFdg3B7t277UVYAh2zatUqNZYWF9BWL+TYsKiLklo3rXd1CJ7fDR/Z2KeAEPK6PY19CgixHWO7NfYpIITc5aVa/vr0Jrc402QvTTC7YWEXJSU6H2MU7PHosIHrbSCflJTk2x/rUHY2nLW4gLY6TW+C2WD8Y0PTFBUR09ingBDyegloW5rImLjGPgU0gqZaOtg60WU3p3n0SwyTlOQX0DopMzPTtiesydw2Py8+Pt5eFtxsgY4xj20sRHQAAACwhg4dqtmzZ6umTz75xO43YmJiNHDgQL9jzPokc7v6mMbQ4jK0AAAAweT2euT2Bmfcg1VYWKjVq1f7teUy7bhSU1PVuXNnu7hry5Yteumll+z9V111le1ecPPNN+vSSy/Vp59+qn//+9+280E107Lr4osv1qBBgzR48GDNmDHDtgebMGGCGgsBLQAAQDO1YMEC21O2ZjBqmIDUXDBh27Zt2rhxo+/+rl272uD1hhtu0EMPPWQX3T377LO200G1cePGaceOHZoyZYpdRNa/f3/b0mvfhWKh1OL60JpVesnJydr9UzdqaFuQU4/Z+0JE88eisJYn57fdG/sUEOJFYUtful35+flBqyU9lBgj+8fOQVsUlnnkxib3vJsCIjoAAACENUoOAAAAHOSx/wvOuAiMDC0AAADCGhlaAAAAB7m9XrsFY1wERoYWAAAAYY0MLQAAgIM88totGOMiMDK0AAAACGtkaAEAABzOpLrJ0IYUGVoAAACENTK0AAAADqKGNvTI0AIAACCskaEFAABwEH1oQ48MLQAAAMIaGVoAAAAHeX7ZgjEuAiNDCwAAgLBGhhYAAMBB7iD1oQ3GmM0FGVoAAACENTK0AAAADnJ7q7ZgjIvAyNACAAAgrJGhBQAAcBBdDkKPDC0AAADCGhlaAAAAB3nkkluuoIyLwMjQAgAAIKyRoQUAAHCQx1u1BWNcBEaGFgAAAGGNDC0AAICD3EGqoQ3GmM0FAS0AAICDCGhDj5IDAAAAhDUytAAAAA7yeF12C8a4CIwMLQAAAMIaGVoAAAAHUUMbemRoAQAAENbI0AIAADjIrQi7OT8u6kKGFgAAAGGNDC0AAICDvEHqcmDGRWBkaAEAABDWyNACAAA4iC4HoUeGFgAAAGGNDC0AAICD3N4Iuzk/ruNDNhtkaAEAABDWyNACAAA4yCOXPEHIGXpEirYuZGgBAAAQ1sjQAgAAOIguB6FHhhYAAABhjQwtAABAWHQ5oIa2LmRoAQAAENbI0AIAADje5cD5etdgjNlckKEFAABAWCNDCwAA4CDTg9ZNH9qQIkMLAACAsEaGNkx9Ma9E/3hitxYtLdO27W69/VymzhzTer+PmfN1sW6aulPLfypTp6xo3XZ9G10yLsnvmMefz9M/Hs9T9g63+vWO0UN3p2nwgLggPxvU14aiH7SuaLHK3cVKjG6rXkm/UkpMRsBjv935f9pdvrXW/rTYwzQw9TT7/c975iu75GeVegrlUqSSo9N0ROIQpcRkBv254MA2Fi/TuuIlKvcUKzGqrXomDlNKdOD5nr/7Xe2uqD3f7WI6a2DKqfb71YXfKbtstUrdhXK5IpQUlaYjWg+pc0yE3o4Vc5WzdI4qSvYoPjVLHYeepVbpnes8PmfZF8pd+bXKC3crKq6VUrr2U9agsYqIim7wmDh0dDkIvXr/tl0u1363adOmNfgk1q9fb8dYsmTJAY+99tprNXDgQMXGxqp///5qqYqKPerXO1aP3JNWr+PXbazQ6Rdu04knxGvRJ5113cRkXXFjjmZ+VuQ75o139+jGabm688ZULZjZSX17x2rM+VuVk1sZxGeC+tpW8rNWFcxV99bH6vh2v1diVDst2PWeytzFAY8f0GaMTkq/xLed0O48ueRSRtzhvmNaRaWoV/Kv7H1D2p6l+MhEO2a5uySEzwyBbCtdrVWFX6l7q0EamnquDWgX5r2vMk/g+e6fPFontr3Yt52QOs7Od2bs3vlOiEpWr8ThOr7tOA1pUzXfZsxyD/PdFOxes1hbvvmvMo85WUeeeYMNPtd89LQNRAPZtXqRtn73gTIHnKxe596izsPHaffaJdq64MMGjwk0+wzttm3bfN+/8cYbmjJlin788Uffvtat958ddNKll16qb7/9VkuXLlVLNWZkK7vV11Mv5atr52j9Y1o7e7tXjxjNnV+qGU/na/RJVePMeCpPl1+QrAnnVWVtn7gvTR/OLtLz/7tHt/y5TZCeCeprfdESdUroo44JveztPsknakfZBm0pWalurQfWOj4mIq5WgBThilJmXHffvqz4Hn7H9Ewaps0lK7WnMldtIzsF7bngwDYUf6+O8b3VIb6nvd07cYR2lG/UlpJV6tbqmAPPd/HPdr5rvoHJittnvlufoC2lq7SncqfaxnQM2nNB/Zhsa9uex6ltj8H2dqdh56hg0wrt/Gm+MvuNrHV8Uc56tcrootTuVf8eYhNT1abbABXv2NDgMeFcDa3ZnB+XDG1d6v3bzszM9G3Jyck2o1pz3+uvv65evXopLi5OPXv21OOPP+4XgPbt21dlZWX2dnl5uQYMGKDx48fb2127drVfzT4z7oknnljneTz88MP605/+pG7dutX31CHpmwWlGjk83m/fyScm6JuFpfb78nKvFi4t8zsmIsKlkcMTNO+XY9B4PF63Cip2qG3s3qDDvFbM7bzy7HqNsbl4hdrHHaGoiOg6f8am4uWKcsUoMbrqjQ8acb4rd/gFmXa+Yzoor2J7vcYwgW/72O6Kcu1nvktXVM13VFvHzh0N43FXqjh3sxKzjvDtM2UhiR16qHj73gC1plbpXVSSu1lFORvt7bKCnSrYtFJJnXo1eEygRdfQvvrqqzZj++ijj9qgdPHixZo4caJatWqliy++2Aah/fr10+TJk/XPf/5Tt99+u/Ly8uzxxvz58zV48GDNmjVLffr0UUxMjBOnhRpMTWxGWqTfPnO7YI9HJSUe7c73yO1WwGN+XF0e4rPFvso9pfLKq5iIBL/9sREJKqrcfcDH55VvV2HlLh2V/Ota9+WUrtf3eTPl9lYqNqKVjk39rWIi/N/8oHHmO3afeTDzX1SZd8DHm6C30L1LfZJqJwdyytZracEnvvkelHI6890EuEuLJK9H0fGJfvuj4lqrNC8n4GNMZraytEg/v/+ovKa20utRu55Dldl/VIPHhDPcXpfdgjEughjQTp06VQ888IDOPvtsX8Z1xYoVeuqpp2xAa8oRXnnlFY0YMUKJiYmaMWOGPvvsMyUlVX20nZZWVQfatm1bm+11kskKV2eGjYKCAkfHB8LB5pIVah3VNuACstSYDjq+3ThVeEq1qXiFluTN1HFtz1VspH/wjPBhsrOtI1MDLvYy8z20ze9V4S2x5SXf53+sIaln2zdHCC97tq7W9u9nq+PxZ6tV+mEqK8jV5nn/UfTiT5Q54DeNfXpASB1ygUdRUZHWrFmjyy67zAau1dvf/vY3u7/a0KFDddNNN2n69Om68cYbNWzYMIXCvffea0skqrdOnVpmXWBmWqS273D77TO3kxIjFB8foXapkYqMVMBjMtJphtHYTH2kWeBjVrvXZBYIHSgQqfRUKLtkta/2dl+mBMEsDjOdDY5O+bVcirCBDhp/vsv2Waxl5n/fLP2+Kr0VtpNBx/g65ttl5jtZKdGZOirpJPsRtAmA0bgi41pJrohai7UqSwtrZVirbVv4kVK7D1S7nscpPrW9UrocbTscZC+ZLa/X06Ax4QzTgzZYGwI75N9MYWGh/frMM8/YLgXV27Jly/TNN9/4jvN4PPrqq68UGRmp1atXK1RuvfVW5efn+7ZNmzapJTpuUJw+nev/H8dZXxTruIFVC0liYlwa2DfW7xiPx6tP5xZr6C/HoPFEuCKVFJ2mnWWbffvMR4zm9oFabGWXrrb1klnxR9brZ5mPus3xaOT5jkrTrvJ95rt8ywFbbG0vXWPnr/0+C8DqYsZlvhtfRGSUEtp11J6tP/v2maB0z5aflZBxWMDHeCorTFHsPgP9ctvbsDGBcHXIqbeMjAxlZWVp7dq1uuCCC+o87v7779eqVav0+eefa/To0Xr++ec1YcIEe191zazbFHE6zLT3MltzU1jk0ep1Fb7b6zdWasmyMqWmRKhzx2jddneutmS79eIjVf/xu3J8sh57Ll+3TM+1XQw++6pEb/63UO+93N43xvVXpmjCdTka2C9Wg/vH6aFn8lRU7NUl5/FOvino0qq/fsibreTodLutL/7e1kF2+CUTtzRvlq2JPDJpqN/jthSvVHpc11qr4E3mdm3hAnufyfKWe0u1segHlbmLlFljZTwax2EJ/bSs4FMb2CZHZ2hD8VK5vRW+rgc/FMy2892j9XF+j9tculLpsQHm21uhtUULlR7bxT7O1OluKlmmMg/z3VSkH/UrbfjidSW066RWaZ2Vs/wLeSrL1faIqg4F6+e8pphWyco6tqqvcHLn3spZ9rkS2nZQQnpnleXn2qyt2e+KiKjXmAgOjzfCbs6PS5eDujjyWfJdd91l+8Oaj/RPOeUUW7O6YMEC7d69W5MmTbKLxMyisbfeeksnnHCCHnzwQV133XW2ptZ0K0hPT1d8fLw++ugjdezY0XZKMGMFYrK7JiucnZ2tkpISX+/a3r17t6jFZAu+L9XIc/Y2UTf9Y43xv0/U8w9laFuOW5u27A14Tcuu915prxun5urhZ/PUsX2Unn4g3deyyxh3RqJyd7o17b5dyt5Rqf59YvXha1nKSKPkoCloH3+E7Rf6c+G3tvdsUnQ7DUo9zVfrWuI2Hyv6Z2sKK3drd8U2DUr8ba3xzKp5s8Bo8e6P7LgmADKBsulHay7agMbVPq67nZfVRd/Z0pKkqHYamHKar8SkxF1Ya77NAsG8imx73L5MCUORO09L8j/2zXdSVLoGtzlTraNSQ/a8ULc2hw+wi7y2LZqpyuICxbftoMNPmajohKqkQkVhnn3dVsscMMr+E9i68P+poijfLvYywWz7QWPrPSbQXLi8dmnkwXnhhRd0/fXX204F1V577TWbhTWLwUx3g6OPPtoeM2bMGHshBFMzaxaJVTvjjDOUm5urL774wpYhPPvss/rrX/+qLVu2aPjw4ZozZ07An21aepks777WrVunLl26HPDczaIwEyzv/qmbrR9Fy3DqMaMb+xQQQl63p7FPASGW89u9/ZXR/LnLS7X0pdttKWH1AvOmoDrGeGbRQCUk+ncNckLxHrcmHrOwyT3vsA1owxkBbctEQNuyENC2PAS0LQsBbdN63k0BnyUDAAA4yBOknrG8Va8bAS0AAEBYXPqWT5brwm8GAAAAYY0MLQAAgIPc3gi7BWNcBMZvBgAAAGGNDC0AAICDPHLZLRjjIjAytAAAAAhrZGgBAAAcRA1t6PGbAQAAQFgjQwsAAOAgtyLsFoxxERi/GQAAAIQ1MrQAAAAO8nhddgvGuAiMDC0AAEAz9thjj6lLly6Ki4vTkCFDNH/+/DqPraio0F//+lcdfvjh9vh+/frpo48+8jtm2rRpcrlcflvPnj3VmMjQAgAAOMgTpBpaM+7BeuONNzRp0iQ9+eSTNpidMWOGRo8erR9//FHp6em1jr/jjjv0yiuv6JlnnrFB6syZM3XWWWfp66+/1oABA3zH9enTR7NmzfLdjopq3JCSDC0AAEAz9eCDD2rixImaMGGCevfubQPbhIQEPffccwGPf/nll3Xbbbdp7Nix6tatm66++mr7/QMPPOB3nAlgMzMzfVu7du3UmAhoAQAAHOTxRgRtOxjl5eVauHChRo0a5dsXERFhb8+bNy/gY8rKymypQU3x8fGaO3eu376ff/5ZWVlZNui94IILtHHjRjUmAloAAIAwUlBQ4LeVlZUFPC43N1dut1sZGRl++83t7OzsgI8x5Qgmq2sCVo/Ho08++UTvvPOOtm3b5jvGlC688MILtrb2iSee0Lp16zR8+HDt2bNHjYWAFgAAwEFuuYK2GZ06dVJycrJvu/feex0794ceekhHHHGErZ+NiYnRNddcY8sVTGa32pgxY/S73/1Offv2tQHwhx9+qLy8PP373/9WY2FRGAAAQBjZtGmTkpKSfLdjY2MDHmfqWiMjI7V9+3a//ea2qXsNJC0tTf/5z39UWlqqnTt32rKCyZMn29KCuqSkpKhHjx5avXq1GgsZWgAAgDCqoTXBbM0tto6A1mRYBw4cqNmzZ+89N4/H3h46dOh+n4Opo+3QoYMqKyv19ttv64wzzqjz2MLCQq1Zs0bt27dXYyGgBQAAaKYmTZpkW3C9+OKLWrlype1aUFRUZMsIjPHjx+vWW2/1Hf/tt9/amtm1a9fqyy+/1CmnnGKD4Jtvvtl3zE033aTPP/9c69evt+28TFsvkwk+//zz1VgoOQAAAHCQ+5c62mCMe7DGjRunHTt2aMqUKXYhWP/+/e1iruqFYqY7Qc36WFNqYHrRmoC2devWtmWXaeVlygqqbd682QavpiTBlCgMGzZM33zzjf2+sRDQAgAANGPXXHON3QKZM2eO3+0RI0ZoxYoV+x3v9ddfV1NDQAsAAOCghvSMre+4CIzfDAAAAMIaGVoAAAAHub0RdgvGuAiM3wwAAADCGhlaAAAAB3nlkicIXQ7MuAiMDC0AAADCGhlaAAAAB1FDG3r8ZgAAABDWyNACAAA4yON12S0Y4yIwMrQAAAAIa2RoAQAAHORWhN2CMS4C4zcDAACAsEaGFgAAwEHU0IYeGVoAAACENTK0AAAADvIowm7BGBeBEdACAAA4yO112S0Y4yIwQn0AAACENTK0AAAADmJRWOiRoQUAAEBYI0MLAADgIK83Qh5vRFDGRWD8ZgAAABDWyNACAAA4yC2X3YIxLgIjQwsAAICwRoYWAADAQR5vcDoSmHERGBlaAAAAhDUytAAAAA7yBKnLQTDGbC74zQAAACCskaEFAABwkEcuuwVjXARGhhYAAABhjQwtAACAg9xel92CMS4CI0MLAACAsEaGFgAAwEF0OQg9fjMAAAAIay02Q/u74SMVFRHT2KeBEPlg0czGPgWE0Ni+Ixv7FBBi6V/mNPYpIIQq3WVq8l0OgnGlMLoc1IkMLQAAAMJai83QAgAABIM3SH1ozbgIjAwtAAAAwhoZWgAAAAeZ+tmg1NDSh7ZOZGgBAAAQ1sjQAgAAOIg+tKHHbwYAAABhjQwtAACAg6ihDT0ytAAAAAhrZGgBAACcvlJYEHrGcqWwupGhBQAAQFgjQwsAAOAgamhDjwwtAAAAwhoZWgAAAAeRoQ09MrQAAAAIa2RoAQAAHESGNvTI0AIAACCskaEFAABwEBna0CNDCwAAgLBGhhYAAMBB3iBd1cuMi8AIaAEAABxEyUHoUXIAAACAsEaGFgAAwEFkaEOPDC0AAADCGhlaAAAAB5GhDT0ytAAAAAhrZGgBAAAcRIY29MjQAgAAIKyRoQUAAHCQ1+uyWzDGRWBkaAEAABDWyNACAAA4yFz2NhiXvg3GmM0FGVoAAACENTK0AAAADqLLQeiRoQUAAEBYI0MLAADgILochB4ZWgAAAIQ1MrQAAAAOooY29MjQAgAAIKyRoQUAAHAQNbShR4YWAAAAYY0MLQAAgMOZ1GDUu5KhrRsZWgAAgGbsscceU5cuXRQXF6chQ4Zo/vz5dR5bUVGhv/71rzr88MPt8f369dNHH310SGOGAgEtAACAg7w2mxqErQHn8sYbb2jSpEmaOnWqFi1aZAPU0aNHKycnJ+Dxd9xxh5566ik98sgjWrFiha666iqdddZZWrx4cYPHDAUCWgAAgGbqwQcf1MSJEzVhwgT17t1bTz75pBISEvTcc88FPP7ll1/WbbfdprFjx6pbt266+uqr7fcPPPBAg8cMBQJaAAAAB3nkCtp2MMrLy7Vw4UKNGjXKty8iIsLenjdvXsDHlJWV2TKCmuLj4zV37twGjxkKBLQAAABhpKCgwG8rKysLeFxubq7cbrcyMjL89pvb2dnZAR9jSgdMBvbnn3+Wx+PRJ598onfeeUfbtm1r8JihQEALAAAQhD60wdiMTp06KTk52bfde++9jp37Qw89pCOOOEI9e/ZUTEyMrrnmGltaYLKwTRltuwAAAMLIpk2blJSU5LsdGxsb8Lh27dopMjJS27dv99tvbmdmZgZ8TFpamv7zn/+otLRUO3fuVFZWliZPnmzraRs6Zig07XAbAAAgzJgetMHaDBPM1txi6whoTYZ14MCBmj179t5z83js7aFDh+73OZg62g4dOqiyslJvv/22zjjjjEMeM5jI0AIAADRTkyZN0sUXX6xBgwZp8ODBmjFjhoqKimwZgTF+/HgbuFaXLXz77bfasmWL+vfvb79OmzbNBqw333xzvcdsDAS0AAAADqruGxuMcQ/WuHHjtGPHDk2ZMsUu2jKBqrlQQvWiro0bN/rVx5pSA9OLdu3atWrdurVt2WVaeaWkpNR7zMbg8nqD8StvusxqQFNAPSpjoqIiYhr7dBAiHyya2dingBAa23dkY58CQi11739s0fxVuss0e/UM5efn+9WSNpUYo88bf1FkQuAygEPhLi7T8nH3N7nn3RSQoQUAAHBQzY4ETo+LwFgUBgAAgLBGhhYAAMBBZGhDj4A2jG0o+kHrihar3F2sxOi26pX0K6XEBC7I/nbn/2l3+dZa+9NiD9PA1NPs9z/vma/skp9V6imUS5FKjk7TEYlDlBLTeH3lUOWLeSX6xxO7tWhpmbZtd+vt5zJ15pjW+33MnK+LddPUnVr+U5k6ZUXrtuvb6JJx/jVXjz+fp388nqfsHW716x2jh+5O0+AB/pc8ROPZWLJM64q/V7mnRIlRbdWz9QlKiU4PeOz8vP9qd0XVlXxqahfTWQOTx9jvVxctUHbZGpW6C+VyRSgpKk1HtDpWKdGNt5AD/jbuXqR1u75VubtIibHp6pk+SinxWQGPnb/xNe0u2VRrf7tW3TSw4+9q7V+ePVOb85foyLRfq0vqsUE5f6CxENCGqW0lP2tVwVz1ST7R/sdofdH3WrDrPQ1P+4NiIxNqHT+gzRh5vW7f7XJPqb7OfUMZcYf79rWKSlGv5F8pITJJbm+lNvwy5q/SLlRMZHzInhtqKyr2qF/vWE04L0nnXnbgSwuu21ih0y/cpivHJ+vlxzL06dxiXXFjjtqnR2r0Sa3sMW+8u0c3TsvV4/+TriED4vTQM3kac/5WrZzbWent+NPQ2LaVrtaqwnnqkzhcyVEZ2lCyVAvzP9Cw1PMUG1H79dg/6WR55fHdrjCv8d1vKTO2qhm6kRCZrF6tT1B8ZJI83kqtL/lBC/M/1PDU8xQTYEyE1raClVq141P1yThZyXFZ2rB7gRZu/reGdZ2o2Kiq121N/Tuc5fd3vcJdoq/XP6/MxJ61jt2+5yfll25VbNT+3wjDGaZfrCsI2dTqPrQ4hBpal8u13830KWuo9evX2zGWLFmy3+O+//57nX/++faSb/Hx8erVq5e9RFtLtL5oiTol9FHHhF5qHZ1qA9tIV5S2lKwMeHxMRJxiI1v5tp3lmxXhilJmXHffMVnxPdQutpMSopJtxrdn0jBVesu1pzI3hM8MgYwZ2UrTJ7fVWWPr9x+jp17KV9fO0frHtHbq1SNGf7o0Reec1lozns73HTPjqTxdfkGyDZJ7HxmjJ+5LU0K8S8//754gPhPU14aSH9Qxrpc6xPVU66g26t36V1Wv8dJVdb/GIxJ8W+4vr/GMGgFtVtwRahvT0b5pbR2Vqp6thv7yGt8ZwmeGumzY/Z06JvdTh+S+ah3bTr0zRisyIlpb8n8IeLxJNJgAtXrLLVqviIhoZSQe6XdcacUercz5RH3bnyYXS2dC2rYrGBsCq3caZtu2vR9lvfHGG7b32I8//ujbZ3qVBdvChQuVnp6uV155xQa1X3/9ta644gp7CTZzreGWwuN1q6Bih7q1HujbZ94QtI3tqLzyA2fvjM3FK9Q+7ghFRUTX+TM2FS9XlCtGidHtHDt3hMY3C0o1crh/xu3kExM0aUrVm5Pycq8WLi3TLX9u47s/IsKlkcMTNG9hacjPFwFe45U71DWhv/9rPLqj8ir8LzdZly2lP6p97OGKcu3nNV66suo1HtXWsXPHIcx5aba6ph7nP+cJXZRXuqVeY2zJX6r2ib38WlKazpw/ZL+vrqlD1Do2LSjnDoRVQFvz+rymx5p5odXc9+yzz+qBBx7QunXr1KVLF1177bX64x//aO+79NJLtWDBAn333Xf28mzl5eUaMmSIjj76aL300kvq2rWrPW7AgAH264gRIzRnzpxa52DGqclcV3jevHl65513WlRAa8oFvPIqJsK/tMBkZYoqdx/w8Xnl21VYuUtHJf+61n05pev1fd5MW3IQG9FKx6b+lo8iw5Cpic1Ii/TbZ24X7PGopMSj3fkeud0KeMyPq8tDfLao6zW+b2mBeS0WVeQd8PF5FTkqdO9Sn8QRte7LKdugpQWz5JZ5jSdoUPKpvMabALMWws75PqUFMZEJKio/cAY9r2SrCstz1Sezql662rpd39isbOeUvQkQBF9VNjUYi8IcH7LZcOSzh1dffdVmbO+++26tXLlS99xzj+688069+OKL9v6HH37YXhJt8uTJ9vbtt9+uvLw8Pfroo/b2/Pnz7ddZs2bZTLAJUOvLNBdOTU2t8/6ysjLb6Ljm1tJtLlmh1lFtAy4gS43poOPbjdNxbc9Ru9jOWpI3U2Xu4kY5TwANY8oSWkemBlxAlhqTpaGp52pIyplqF9NJ3xfMUpmnpFHOE84x2dnWMWl+C8jyS7O1YfdCHdV+rE1CAc2ZIys/pk6darOzZ599tr1tMq4rVqzQU089Za/1a8oRTJmAybwmJibaa/5+9tlnvqtcpKVVfQzStm1bv6zvgZiSA1P+8MEHH9R5jLk28V133aXmxNTKueRSucc/0CzzFNuMy/5UeiqUXbJa3RMHB7zflCBERVRdccd0N/gi5xVtLlmpw2uUN6Dpy0yL1PYdexeLGOZ2UmKE4uMjFBnpUmSkAh6Tkc6CsKbyGt830DTdDg6UTa30VthOBt0TBgW835QgREUmS5HJdkHpl7v+1wbA3RKqPiFD4zCZWDvnlUW1MrcxARaE1VTpKVf2npXq3m643/7dxZtst4Qv1jzh22eywD/u+MwuOBtx+NUOPwtUo21XGGZoTeZ1zZo1uuyyy2zgWr397W9/s/urDR06VDfddJOmT5+uG2+8UcOGDTukn7ts2TKdccYZNpg++eST6zzu1ltvtVnc6m3TptotTsJNhCtSSdFp2lm22a9Oytw+UIut7NLVtlYrK95/0UBdzB8/czzCy3GD4vTpXP9gaNYXxTpuYFVLrpgYlwb2jfU7xuPx2m4IQ385Bo38Go9K067yLf6v8YotB2yxtb1srX3Nmhr5+n6EyWu8icx5XKZ2FW/wn/Pi9UqJ67Dfx27f82PVnCf18duflXyUju9yqYZ2meDbzOKxrqmDNajT74P2XIDGcMipmMLCQvv1mWeesXWxNZnFWtU8Ho+++uoru2/16tWH9DNN9nfkyJF2Qdgdd9yx32NNza7Zmpsurfrrh7zZSo5Ot9v64u9t3WuH+F72/qV5s2wN7JFJQ/0et6V4pdLjutoM0L6Z27WFC+x9Jstb7i3VxqIfVOYuUmaN1l5oHIVFHq1eV+G7vX5jpZYsK1NqSoQ6d4zWbXfnaku2Wy8+UhXsmHZdjz2Xr1um59ouBp99VaI3/1uo915u7xvj+itTNOG6HA3sF6vB/avadhUVe3XJeYmN8hzh77D4o7Vszxz75jU5Kt12PXB7K9QhrurN6A8Fn9rXeI/W/n93N5esUnpsl9qvcW+F1hYtsvfZ17inVJtKl6vMU+TX2guN57A2x2pZ9gc2sE2Oa2+zqG5PhTokH23v/2Hb+4qNSlSPNP/a6M35S5Xe+oha7RXN7X33mXramMhWahXDQsBgMqWuwSh3pYQ2iAFtRkaGsrKytHbtWl1wwQV1Hnf//fdr1apV+vzzzzV69Gg9//zzmjBhgr0vJqZqRabbrFI5gOXLl+vXv/61LWUwNbstVfv4I+zHjz8XfmtrXJOi22lQ6mm+HrQlbtN6yf+jicLK3bbx+qDE39Yaz9RXFVXmafHuj375WDPOBspD2p5lW3ihcS34vlQjz9l7YQzTP9YY//tEPf9QhrbluLVpy96A17Tseu+V9rpxaq4efjZPHdtH6ekH0n09aI1xZyQqd6db0+7bpewdlerfJ1YfvpaljDRKDpqC9nHd7RtLczEEU06UFNVOA5PH+sqKSjyFtV7j5jWcV5mtga1OrTWe+Ti7yJ2nJQUf22DWvMZNFnhwym9tCy80vvZJvWyJwercuTaZkBSbroEdf+9bKFZSUVB7zst3Kq9ksz0OaMlcXvOZxkF64YUXdP3119uFXdUdDkxXg7///e865ZRT7EIs09Vg9+7dmjRpkhYvXqzjjjtOb731lk4//XQ9/fTTtvzA9J01nQoqKyttPa1ZLHb55ZcrLi7OdlIIVGZgglkTEJsAuZrJ+lbX4R6IWRRmxh6VMdGvtQmatw8WzWzsU0AIje07srFPAaGWWlX7j5ah0l2m2atn2FLC6vU4TUF1jNHtpdsUmeB8+Za7uFRrx9/T5J53s+lyYIJQE9SarKtpxWUWf5mg1ywOKy0t1YUXXqhLLrnEBrOGKRU46aSTdNFFF9msbFRUlO2EYBaRmWyvqY0NxATEO3bssAvM2rdv79uOPZZL+AEAADR15hP9JpOhDWdkaFsmMrQtCxnaFogMbYvS5DO0LwYxQ3txeGdoIyIibOLTNBM499xz7afyjozryCgAAADAASxatEh9+/a1JammVeuVV17pux7BoSCgBQAAcNIvfWid3sy44a5///566KGHtHXrVj333HP2glqmletRRx2lBx980JaWNgQBLQAAAELKrJ8yF+R688039T//8z+2patpGNCpUyeNHz/eBroHg4AWAADAQWZ1UrC25mLBggX64x//aBf3m8ysCWbNBbk++eQTm72tq0FAXWg4CQAAgJAwwavpivXjjz9q7Nixeumll+xXs1jMMB2yTKesLl26HNS4BLQAAAAO8tW8BmHccPfEE0/o0ksvte1cTXY2kPT0dP3rX/86qHEJaAEAABASpqSgc+fOvoxsNdNFdtOmTfY+cwVZc0XYg0ENLQAAgJOqOxIEYwtzhx9+uHJzqy7fXtOuXbtsuUFDEdACAAAgJOq6nldhYeEhXWSBkgMAAAAHBasjQTh3OZg0aZL96nK5NGXKFCUkJPjuc7vd+vbbb22P2oYioAUAAEBQLV682Jeh/eGHH2ydbDXzfb9+/WzrroYioAUAAHCSyaQGI5saxhnazz77zH6dMGGCvVJYUlKSo+MT0AIAACAkTA/aYCCgBQAAcBB9aP2ZS9yaiyWYrKz5fn/eeecdNQQBLQAAAIImOTnZLgar/j4YCGgBAACcFsb1rsEqMzALwu666y6lpaUpPj7e0Z9BH1oAAAAEnQlou3fvrs2bNzs+NgEtAABAEGpog7GFs4iICB1xxBHauXOn82M7PiIAAAAQwN///nf95S9/0bJly+QkamgBAACcRB/aOo0fP17FxcX2Qgrmggr71tLu2rVLDUFACwAAgJCYMWNGUMYloAUAAHCUqXUNRr1reNfQGhdffLGCgYAWAAAAIVdaWqry8nK/fQ29JC6LwgAAAIJRQxuMLcwVFRXpmmuuUXp6ulq1aqU2bdr4bQ1FQAsAAICQuPnmm/Xpp5/qiSeeUGxsrJ599ll7sYWsrCy99NJLDR6XkgMAAAAn0eWgTu+9954NXE888URNmDBBw4cPtxdbOOyww/Tqq6/qggsuUEOQoQUAAEBImLZc3bp189XLVrfpGjZsmL744osGj0tACwAA4CRzRa9gbWGuW7duWrdunf2+Z8+e+ve//+3L3KakpDR4XAJaAAAAB3m9wdvC3YQJE/T999/b7ydPnqzHHntMcXFxuuGGG+wVxBqKGloAAACEhAlcq40aNUqrVq3SwoULbR1t3759GzwuAS0AAICTWBRWb2YxmNkOFQEtAAAAgubhhx+u97HXXnttg34GAS0AAICTgrWAK0wXhf3zn/+s13Eul4uAFgAAAE1PdVeDYCKgBQAAcJDLW7UFY1wERkALAACAoJk0aZKmT5+uVq1a2e/358EHH2zQzyCgBQAAcBJdDvwsXrxYFRUVvu/3V0PbUAS0AAAACJrPPvss4PdOIqAFAABwEl0OQo6AFgAAACFRWlqqRx55xGZqc3Jy5PF4/O5ftGhRg8YloAUAAHASNbR1uuyyy/Txxx/r3HPP1eDBgw+pbrYmAloAAACExPvvv68PP/xQJ5xwgqPjEtACAAA4iQxtnTp06KDExEQ5LcLxEQEAAIAAHnjgAd1yyy3asGGDnESGFgAAwElkaOs0aNAguzCsW7duSkhIUHR0tN/9u3btUkMQ0AIAACAkzj//fG3ZskX33HOPMjIyWBQGAADQJNGHtk5ff/215s2bp379+slJ1NACAAAgJHr27KmSkhLHxyWgBQAAcJDLG7wt3P3973/XjTfeqDlz5mjnzp0qKCjw2xqKkgMAAACExCmnnGK/jhw50m+/1+u19bRut7tB4xLQAgAAOIkuB3Uyl7wNBgJaAAAAhMSIESOCMi4BLQAAAIJm6dKlOuqooxQREWG/35++ffs26GcQ0AIAACBo+vfvr+zsbKWnp9vvTa2sqZndFzW0AAAATYTpFhuMjgTh2oV23bp1SktL830fDC02oPW6PfJ6PY19GgiRsX39V1Oieftw6ezGPgWE2Ois/o19Cgght7eisU8BB+Gwww4L+L2T6EMLAAAQjCuFBWMLUz/99JPmz5/vt2/27Nk66aSTNHjwYHsp3ENBQAsAAICguuWWW/T+++/7bpvSg9NPP10xMTEaOnSo7r33Xs2YMaPB47fYkgMAAICgoA9tLQsWLNDNN9/su/3qq6+qR48emjlzpq+7wSOPPKLrr79eDUGGFgAAoBl77LHH1KVLF8XFxWnIkCG1Pvrfl8mUHnnkkYqPj1enTp10ww03qLS01Hf/tGnTbEeCmlvPnj33O2Zubq46duzod4EFk6GtduKJJ2r9+vUNfo4EtAAAAMHI0AZjO0hvvPGGJk2apKlTp2rRokXq16+fRo8erZycnIDHv/baa5o8ebI9fuXKlfrXv/5lx7jtttv8juvTp4+2bdvm2+bOnbvf80hNTbXHGR6Px2ZsjzvuON/95eXlAVt51RcBLQAAQDP14IMPauLEiZowYYJ69+6tJ598UgkJCXruuecCHv/111/rhBNO0B/+8Aeb1T355JN1/vnn18rqRkVFKTMz07e1a9duv+dhMrDTp0/Xpk2bbAbYBLVmX7UVK1bYn9dQBLQAAAAOMj1og7UZBQUFfltZWVnA8zBZz4ULF2rUqFG+feZqXeb2vHnzAj7m+OOPt4+pDmDXrl2rDz/8UGPHjvU77ueff1ZWVpa6deumCy64QBs3btzv7+Tuu+/WqlWrbNsus0DsvvvuU6tWrXz3v/zyy/r1r3+thmJRGAAAQBgxda01TZ061da1BqpbNVfeysjI8NtvbpvgMhCTmTWPGzZsmC0BqKys1FVXXeVXcmDqcF944QVbZ2vKCO666y4NHz5cy5YtU2JiYsBxTfbVlDAsX77cXmTBBMM1mTFq1tgeLAJaAACAMOpyYD62T0pK8u2OjY117EfMmTPH9oR9/PHHbeC6evVqXXfddbZc4M4777THjBkzxne86U5gjjOZ13//+9+67LLL6hzblCmYGt5A6tpfXwS0AAAAYRTQmmC2ZkBbF1PXGhkZqe3bt/vtN7dN3WsgJmi96KKLdPnll9vbRx99tIqKinTFFVfo9ttvtyUL+0pJSbEtuEzw21iooQUAAGiGYmJiNHDgQHtFrmpmMZa5bS5mEEhxcXGtoNUExUZdXQgKCwu1Zs0atW/fXo2FDC0AAICDai7gcnrcgzVp0iRdfPHFGjRokL3ErOkwYDKupuuBMX78eHXo0MFeqcswvWFNZ4QBAwb4Sg5M1tbsrw5sb7rpJnvblBls3brV1vCa+0w3hMZCQAsAANBMjRs3Tjt27NCUKVOUnZ2t/v3766OPPvItFDPdCWpmZO+44w57oQTzdcuWLXYBlwleTZeCaps3b7bB686dO+39ZgHZN998Y79vLC7voXSxDUOmvUVycrJGtrtMURExjX06CBWvp7HPACH04dK9H6+hZRid1b+xTwEhVOmt0By9q/z8/HrVkoY6xuh61z2KiItzfHxPaanWTb2tyT3vg/Xll1/qqaeesmUKb731ls0Qm7ZdXbt2tcFxQ1BDCwAAgJB4++237ZXKzGV1Fy9e7Ouha4J0012hoQhoAQAAmumlb5uav/3tb/ZqZc8884yio6N9+83VycyleRuKgBYAAAAh8eOPP+pXv/pVrf2mVCMvL6/B4xLQAgAAhNGlb8NZZmZmwH61c+fOtZfRbSgCWgAAAITExIkT7ZXHvv32W9tNwbT9evXVV20rsKuvvrrB49K2CwAAIIyuFBbOJk+ebC/uMHLkSHsRB1N+YC7dawLaP//5zw0el4AWAAAAIWGysuYSun/5y19s6YG5yljv3r3VunXrQxqXgBYAAMBJwap3bQYZ2pqX5TWBrFMIaAEAABAS5rK7f//73zV79mzl5OTY8oOa1q5d26BxCWgBAACcRA1tnS6//HJ9/vnnuuiii9S+fXtbguAEAloAAACExP/7f/9PH3zwgb2QgpMIaAEAAJxEhrZObdq0UWpqqpxGH1oAAACExPTp0zVlyhTbsstJZGgBAAAcFKyrejWHK4U98MADWrNmjTIyMtSlSxdFR0f73b9o0aIGjUtACwAAgJA488wzgzIuAS0AAABCYurUqUEZlxpaAAAAhDUytAAAAE6iy4Ef09Xgp59+Urt27WyXg/31nt21a5cagoAWAAAAQfPPf/5TiYmJvu+duphCTQS0AAAADqLLgb+LL77Y9/0ll1yiYKCGFgAAACFh2nL98MMPvtvvvvuu7Xxw2223qby8vMHjEtACAAAEq47Wya0ZuPLKK209rbF27VqNGzdOCQkJevPNN3XzzTc3eFwCWgAAAISECWb79+9vvzdB7IgRI/Taa6/phRde0Ntvv93gcamhBQAAcBJdDurk9Xrl8Xjs97NmzdJpp51mv+/UqZNyc3PVUGRoAQAAEBKDBg3S3/72N7388sv6/PPPdeqpp9r969ats5fDbSgytAAAAA6iy0HdZsyYoQsuuED/+c9/dPvtt6t79+52/1tvvaXjjz9eDUVACwAAgJDo27evX5eDavfff78iIyMbPC4BLQAAgJOooT2ghQsXauXKlfb73r1765hjjtGhIKAFAABASOTk5NhWXaZ+NiUlxe7Ly8vTSSedpNdff11paWkNGpdFYQAAAEGooQ3GFu7+/Oc/q7CwUMuXL9euXbvstmzZMhUUFOjaa69t8LhkaAEAABASH330kW3X1atXL98+U3Lw2GOP6eSTT27wuAS0AAAATqKGtk6mB210dHSt/WZfdX/ahqDkAAAAoKlf9raZXP7217/+ta677jpt3brVt2/Lli264YYbNHLkyAaPS0ALAACAkHj00UdtvWyXLl10+OGH261r16523yOPPNLgcSk5AAAAcBAXVqibucTtokWLbB3tqlWr7D5TTztq1CgdCgJaAAAAhIzL5dJvfvMbuzmFkgMAAAAnUUNby6effmq7GZjSgn3l5+erT58++vLLL9VQBLQAAAAIqhkzZmjixIlKSkqqdV9ycrKuvPJKPfjggw0en4AWAADASWRoa/n+++91yimnqC6mB625HG5DEdACAAAgqLZv3x6w/2y1qKgo7dixo8HjE9ACAAA4iEvf1tahQwd7idu6LF26VO3bt1dDEdACAAAgqMaOHas777xTpaWlte4rKSnR1KlTddpppzV4fNp2hbGNxcu0rniJyj3FSoxqq56Jw5QSnRHw2Pm739Xuir1X5ajWLqazBqacar9fXfidsstWq9RdKJcrQklRaTqi9ZA6x0TobSwxc/69yj0lVXPe+gSlRKcHPHZ+3n+1u2Jb4DlPHmO/X120QNlla/znvNWxzHkT8MW8Ev3jid1atLRM27a79fZzmTpzTOv9PmbO18W6aepOLf+pTJ2yonXb9W10yTj/BRiPP5+nfzyep+wdbvXrHaOH7k7T4AFxQX42qK9N3tXaoJ9UrlK1VrKO1AAlu1IDHrvAO0d5yq21v60yNcA1zH6f492izVqjPcpThco1RKOU6EoJ+vNo8bj0bS133HGH3nnnHfXo0UPXXHONjjzySLvf9KJ97LHH5Ha7dfvtt6uhCGjD1LbS1VpV+JX6JI5QcnS6NhQv1cK89zWs7fmKjUiodXz/5NHyevdeI7nCW6qvd/1bmbGH+/YlRCWrV8xwxUcmyeOt1Pri7+2Yw9v+QTER8SF7btjfnM9Tn8ThSo7K0IaSpVqY/4GGpZ6n2ADz0z/pZHlVY849pfp691vKjO3m25cQmaxerU/YO+clP2hh/ocannoec97Iioo96tc7VhPOS9K5l2Uf8Ph1Gyt0+oXbdOX4ZL38WIY+nVusK27MUfv0SI0+qZU95o139+jGabl6/H/SNWRAnB56Jk9jzt+qlXM7K70d/zlobNneTfpJS9VLxyhJqdqkn7VYX+p472jFuGq/6ein4+Wp+RpXmb7VLGWoo2+fW5VKUTtlqJNWquELboBDlZGRoa+//lpXX321br31Vnm9Xl9P2tGjR9ug1hwT9JID8wP3t02bNq3BJ7F+/Xo7xpIlS/Z73M6dO+0KuaysLMXGxtqrTZgoP1BPs+ZuQ/H36hjfWx3ie6p1VKp6J45QpCtaW0qqrrqxr5iIOMVGJvi23PJNinBFKSNub0CbFddDbWM6KiEyyY5psn+V3nLtqdwZwmeGumwo+UEd43qpQ5yZ8zbq3fpXinRFaUvpfuY8IsG35ZZvrprzGgFtVtwR/nPeaihz3kSMGdlK0ye31Vlj95+VrfbUS/nq2jla/5jWTr16xOhPl6bonNNaa8bT+b5jZjyVp8svSLZBcu8jY/TEfWlKiHfp+f/dE8RngvraqJ/UQV2V5eqi1q4k9dQxilSktmp9wOOjXTGKdcX5tl3KUYQi/QLa9q7D1M3VW6kK/EkOgoMa2sAOO+wwffjhh8rNzdW3336rb775xn5v9pnL3x6Ker8l37Zt70eXb7zxhqZMmaIff/zRt6916/r90T0UEREROuOMM/S3v/1NaWlpWr16tf70pz9p165deu2119RSeLxuFVTuUNdWx/j2mTcEbWM6KK9ie73GMIFv+9juinJF1/kzNpWuUJQrxn60jSYy5wn9/ec8umP957z0R7WPPfwAc76SOQ9T3ywo1cjh/ln1k09M0KQpVR9Jl5d7tXBpmW75cxvf/RERLo0cnqB5C2vXtCG0PF6PLQvoop5+r/FUb4byVL83mFu0TpnqZN/oAk1ZmzZtdOyxxzo6Zr0ztJmZmb7NNMA1L7Sa+15//XV7Ld64uDj17NlTjz/+uO+xl156qfr27auysjJ7u7y8XAMGDND48ePt7eqo3Owz45544ol1/gJMqnrQoEE2yh85cqT++Mc/HtKVJcJRuadUXnlrfcwcE5Fg62kPxARAhe5d6hDfq9Z9OWXrNWvHM/pkx9O2jGFQyul89Nyk5zze1tMeSF5FTtWcxwWa8w2ateNf+iT3WVvGMCj5VOY8DJma2Iy0SL995nbBHo9KSjzK3eWW262Ax2zPqQzx2WJfplzAvMZj5F9aEKNYW097IPneXSpSgbJ0aFkuOIQ+tCHnSJeDV1991WZs7777bq1cuVL33HOPXcn24osv2vsffvhhFRUVafLkyfa2KfrNy8vTo48+am/Pnz/ffp01a5bNBJui4frYunWrPXbEiBF1HmOCaFOSUHNr6Ux2tnVkasCFP6kxHTS0ze81pM1ZahfTSd/nf6yyegTJaNpMWULVnNf+2DE1JktDU8/VkJQzq+a8YJbK6hEkA2g6tmqdXURW1wIyoLlzJKA1rRYeeOABnX322Tbbar7ecMMNeuqpp3zlCK+88oot+DWBr7n82csvv+y7/JkpHzDatm1rs72pqft/QZ5//vlKSEiwPc3MGM8++2ydx9577702o1y9mbrbcGdqI11y1Qo6THbWZGn3p9JbYTsZdAyQnTXMx9GtopKVEp2po5JOsivf66rLRVOY85IDZlOr5nyNOsbt/Siz1pxHmjnP0FGJJ9pPSeqqy0XTlWkyrTvcfvvM7aTECMXHR6hdaqQiIxXwmIx0PqJubNGKta/xfbOx5SqrlbXdl9tbqWxtUpa6BPksUW9kaMMvoDWZ1zVr1uiyyy6zgWv1Zupczf5qQ4cO1U033aTp06frxhtv1LBhVS1FGuKf//ynFi1apHfffdf+jEmTJtV5rFlJl5+f79s2bdqkcBfhirTtlXaVb/btM6sFd5ZvOWC7pe2la2ytZPu4HvX6WWZcczyaypxv8Z/zinrMednaX+b8iHr9LLPwlDkPP8cNitOnc/3f8Mz6oljHDawKhmJiXBrYN9bvGI/Ha7shDP3lGDSeCFeEEpViF3bVfI2b2ynaf037dm22HU0y1TkEZwo0TYf8trywsNB+feaZZzRkyBC/+yJNOuAXHo9HX331ld1nFnMdiuq6XVOra7K5w4cPtyUOga4wYbohmK25OSyhn5YVfGqDnOToDFvv6vZW2K4Hxg8FsxUb0Uo9Wh/n97jNpSuVHtvVZvz2zeKtLVqo9Ngu9nGmZnNTyTKVeYqUWaMTAhrPYfFHa9meOUqKTlNyVLrtemDnPK6ql98PBZ/+Muf+r8PNJavsvAae80W/zLmpvy7VptLlVXNeoxMCGkdhkUer11X4bq/fWKkly8qUmhKhzh2jddvdudqS7daLj1S9oTHtuh57Ll+3TM+1XQw++6pEb/63UO+9vPfv4vVXpmjCdTka2C9Wg/tXte0qKvbqkvMSG+U5wl9n9dAKfackbxslK1Ub9bNtu9X+l8zrMu98xSle3V1H1yo3SFOWYly1/1tX4TU532KVqeqNTJH22CyfyfqazggIDtcvWzDGRZACWtMzzLTRWrt2rS644II6j7v//vtt89zPP//c9ht7/vnnNWHCBHtfTEyM/Wqa6h4sEygb1QvOWor2cd3tx82ri76zNa5JUe00MOU0Xw/aEndhrX/6RZW7lVeRbY/bl/moq8idpyX5H//yMXackqLSNbjNmbadE5rInHtL7cUQfHOePHbvnHsCzXme8iqzNbBV1cUzAs55gZnz0l/mPE2DU37LnDcBC74v1chz9l4MxfSPNcb/PlHPP5ShbTlubdqyN+A1Lbvee6W9bpyaq4efzVPH9lF6+oF0Xw9aY9wZicrd6da0+3Ype0el+veJ1YevZSkjjZKDpiDT1UkV3jKt1QqVqVSJStYADfMFniYwNa/bmoq8pjfCTg3Q8IBj7tBWrdAC3+1l+tZ+7apeOlx9gvp8gFByeas72x6EF154Qddff71d2GWYGtZrr71Wf//7322fWBNcLliwQLt377blAIsXL9Zxxx2nt956S6effrqefvppW35g+s5269ZNlZWVthbWLBa7/PLLbacEU++6L9OnbPv27bbVgylrWL58uf7yl7/YLO3cuXPrde5mUZgZe2S7yxQVURVIowWocVEJNH8fLp3d2KeAEBudtbelHZo/8wnTHL1rSwmr1+M0BdUxRu+r71FkrPMZcHdZqVY8cVuTe97NZlGYCUJNUGuyrkcffbTtOmCCXrNAzFyz98ILL9Qll1xig1njiiuu0EknnaSLLrrIZmWjoqJsJwSziMxke02v2UDi4+NtaYOpvzUtwszCs9/+9rd6//33nXgaAAAAaCkZ2nBGhraFIkPbopChbXnI0LYsTT1D2+eq4GVolz9JhjZoGVoAAACgsbASAAAAwEnB6hnboj5TPzhkaAEAABDWyNACAAA4jWxqSJGhBQAAQFgjQwsAAOAgl7dqC8a4CIwMLQAAAMIaGVoAAAAn0eUg5MjQAgAAIKyRoQUAAHAQNbShR4YWAAAAYY0MLQAAgJOooQ05MrQAAAAIa2RoAQAAHEQNbeiRoQUAAEBYI0MLAADgJGpoQ46AFgAAwEkEtCFHyQEAAADCGhlaAAAAB7EoLPTI0AIAADRjjz32mLp06aK4uDgNGTJE8+fP3+/xM2bM0JFHHqn4+Hh16tRJN9xwg0pLSw9pzGAjoAUAAAhGDW0wtoP0xhtvaNKkSZo6daoWLVqkfv36afTo0crJyQl4/GuvvabJkyfb41euXKl//etfdozbbrutwWOGAgEtAABAM/Xggw9q4sSJmjBhgnr37q0nn3xSCQkJeu655wIe//XXX+uEE07QH/7wB5uBPfnkk3X++ef7ZWAPdsxQIKAFAABwkMvrDdp2MMrLy7Vw4UKNGjXKty8iIsLenjdvXsDHHH/88fYx1QHs2rVr9eGHH2rs2LENHjMUWBQGAAAQRgoKCvxux8bG2m1fubm5crvdysjI8Ntvbq9atSrg2CYzax43bNgweb1eVVZW6qqrrvKVHDRkzFAgQwsAABBGNbRmoVZycrJvu/feex079Tlz5uiee+7R448/butj33nnHX3wwQeaPn26mjIytAAAAGFk06ZNSkpK8t2ODZCdNdq1a6fIyEht377db7+5nZmZGfAxd955py666CJdfvnl9vbRRx+toqIiXXHFFbr99tsbNGYokKEFAAAIQh/aYGyGCWZrbrF1BLQxMTEaOHCgZs+e7dvn8Xjs7aFDhwZ8THFxsa2JrckEsIYpQWjImKFAhhYAAKCZmjRpki6++GINGjRIgwcPtj1mTcbVdCgwxo8frw4dOvjKFk4//XTbxWDAgAG2v+zq1att1tbsrw5sDzRmYyCgBQAAcFIDe8bWa9yDNG7cOO3YsUNTpkxRdna2+vfvr48++si3qGvjxo1+Gdk77rhDLpfLft2yZYvS0tJsMHv33XfXe8zG4PKa/HELWxloCqhHtrtMURExjX06CBWvp7HPACH04dK9H4WhZRid1b+xTwEhVOmt0By9q/z8fL9a0qYSYwz4w92KjIlzfHx3eakWv3Z7k3veTQEZWgAAAAfVrHd1elwExqIwAAAAhDUytAAAAM20hralIEMLAACAsEaGFgAAwEHU0IYeGVoAAACENTK0AAAATqKGNuTI0AIAACCskaEFAABwGPWuoUWGFgAAAGGNDC0AAICTvN6qLRjjIiAytAAAAAhrZGgBAAAcRB/a0CNDCwAAgLBGhhYAAMBJ9KENOTK0AAAACGtkaAEAABzk8lRtwRgXgZGhBQAAQFgjQwsAAOAkamhDjgwtAAAAwhoZWgAAAAfRhzb0yNACAAAgrJGhBQAAcJLXW7UFY1wEREALAADgIEoOQo+SAwAAAIS1Fpuh3TG2myJj4hr7NBAi6V/mNPYpIIRGZ/Vv7FNAiM3cuqSxTwEhVLDHozY91HTRtivkyNACAAAgrLXYDC0AAEAwUEMbemRoAQAAENbI0AIAADiJtl0hR4YWAAAAYY0MLQAAgIOooQ09MrQAAAAIa2RoAQAAnEQf2pAjQwsAAICwRoYWAADAQdTQhh4ZWgAAAIQ1MrQAAABO8nirtmCMi4DI0AIAACCskaEFAABwEl0OQo4MLQAAAMIaGVoAAAAHuYLUkcCMi8DI0AIAACCskaEFAABwktdbtQVjXAREhhYAAABhjQwtAACAg7hSWOiRoQUAAEBYI0MLAADgJPrQhhwZWgAAAIQ1MrQAAAAOcnm9dgvGuAiMDC0AAADCGhlaAAAAJ3l+2YIxLgIiQwsAAICwRoYWAADAQdTQhh4ZWgAAAIQ1MrQAAABOog9tyJGhBQAAQFgjQwsAAOAkU+sajHpXamjrRIYWAAAAYY0MLQAAgINc3qotGOMiMAJaAAAAJ1FyEHKUHAAAACCskaEFAABwkMtTtQVjXARGhhYAAABhjQwtAACAk6ihDTkytAAAAAhrZGgBAACcxKVvQ44MLQAAAMIaGVoAAAAHubxeuwVjXARGhhYAAABhjQwtAACAk+hyEHJkaAEAABDWyNACAAA4ySRSg3FVLxK0dSJDCwAAgLBGhhYAAMBBdDkIPTK0AAAAzdhjjz2mLl26KC4uTkOGDNH8+fPrPPbEE0+Uy+WqtZ166qm+Yy655JJa959yyilqTGRoAQAAHL9SWDC6HBz8Q9544w1NmjRJTz75pA1mZ8yYodGjR+vHH39Uenp6rePfeecdlZeX+27v3LlT/fr10+9+9zu/40wA+/zzz/tux8bGqjGRoQUAAGimHnzwQU2cOFETJkxQ7969bWCbkJCg5557LuDxqampyszM9G2ffPKJPX7fgNYEsDWPa9OmjRoTAS0AAEAw+tAGYzsI5eXlWrhwoUaNGuXbFxERYW/PmzevXmP861//0nnnnadWrVr57Z8zZ47N8B555JG6+uqrbSa3MVFyAAAAEEYKCgpqZUtjA3zkn5ubK7fbrYyMDL/95vaqVasO+HNMre2yZctsULtvucHZZ5+trl27as2aNbrttts0ZswYGyRHRkaqMRDQAgAAOMn0oHUFaVxJnTp18ts9depUTZs2zfEfZwLZo48+WoMHD/bbbzK21cz9ffv21eGHH26ztiNHjlRjIKAFAAAII5s2bVJSUtIBF2S1a9fOZky3b9/ut9/cNnWv+1NUVKTXX39df/3rXw94Pt26dbM/a/Xq1QS0OHg7VsxVztI5qijZo/jULHUcepZapXeu8/icZV8od+XXKi/crai4Vkrp2k9Zg8YqIiq6wWMitDbuXqR1u75VubtIibHp6pk+SinxWQGPnb/xNe0u2VRrf7tW3TSwo39xv7E8e6Y25y/RkWm/VpfUY4Ny/jg4m7yrtUE/qVylaq1kHakBSnalBjx2gXeO8pRba39bZWqAa5j9Pse7RZu1RnuUpwqVa4hGKdGVEvTngfr5Yl6J/vHEbi1aWqZt2916+7lMnTmm9X4fM+frYt00daeW/1SmTlnRuu36Nrpk3N5Ax3j8+Tz94/E8Ze9wq1/vGD10d5oGD4gL8rNp2YLdh9YEszUD2rrExMRo4MCBmj17ts4880y7z+Px2NvXXHON9ufNN99UWVmZLrzwQh3I5s2bbQ1t+/bt1eQXhQXqSVZzO5RU9/r16+0YS5YsqfdjzC+uY8eO9nF5eXlqaXavWawt3/xXmcecrCPPvMEGn2s+etoGooHsWr1IW7/7QJkDTlavc29R5+HjtHvtEm1d8GGDx0RobStYqVU7PlX3dido6GGX2IB24eZ/q6yyKODx/TucpRMP/5NvO6HLpXLJpczEnrWO3b7nJ+WXblVs1P7/44nQyfZu0k9aqm7qrcEm8FSKFutLlXtLAx7fT8druE7zbcfpN3a+M9TRd4xblUpRO3XX0SF8JqivomKP+vWO1SP3pNXr+HUbK3T6hdt04gnxWvRJZ103MVlX3JijmZ/t/Zvwxrt7dOO0XN15Y6oWzOykvr1jNeb8rcrJrQziM0FTMmnSJD3zzDN68cUXtXLlSruAy2RfTdcDY/z48br11lsDlhuYILht27Z++wsLC/WXv/xF33zzjY3fTHB8xhlnqHv37rYdWGOpd4Z227Ztfj3NpkyZYnuYVWvdOrT/IbzssstszcaWLVvUEplsa9uex6ltj6q6lk7DzlHBphXa+dN8Zfarne4vylmvVhldlNr9GHs7NjFVbboNUPGODQ0eE6G1Yfd36pjcTx2S+9rbvTNGa0fRGm3J/0Hd2h5X6/iYyPhaAXFERLQyEo/0219asUcrcz7RoI6/18LNbwX5WaC+NuondVBXZbm62Ns9vccoV9u0VevVRbXflES7Yvxub/duUoQi/QLa9q7D7NcSb+A3QWhcY0a2slt9PfVSvrp2jtY/prWzt3v1iNHc+aWa8XS+Rp9UNc6Mp/J0+QXJmnBeVTbvifvS9OHsIj3/v3t0y58bt81Ss9aAjgT1HvcgjRs3Tjt27LBxW3Z2tvr376+PPvrIt1Bs48aNtvNBTSa+mzt3rj7++ONa45kShqVLl9oA2SQUs7KydPLJJ2v69OmN2ou23hnamr3GkpOTbWa05j5TZ9GrVy97FYqePXvq8ccf9z320ksvtcGnSV1Xt5EYMGCAfVdgmFVyhtlnxjVXqdifJ554wv4Sb7rpJrVEHnelinM3KzHrCN8+lytCiR16qHj73gC1plbpXVSSu1lFORvt7bKCnSrYtFJJnXo1eEyEjsfrVkFpttomVAUkhnmttE3oorzS+r2p25K/VO0TeykqYm/g4/V69UP2++qaOkStY+uXFULwebweWxaQqnS/+U5VhvJUv9Y4W7ROmeqkSBeVZc3VNwtKNXK4/xvXk09M0DcLq7L45eVeLVxa5ndMRIRLI4cnaN4vx6BluOaaa7RhwwYbh3377bf2AgvVzEKuF154we9404rL/PfhN7/5Ta2x4uPjNXPmTOXk5Nh4zmRpn3766VqdFELNkb90r776qo38H330URuULl682DbxNT3LLr74Yj388MP2KhOTJ0/WP//5T91+++02IDXHV7eFMCvoZs2apT59+tiaj7qsWLHCFiibCVm7dq1aIndpkeT1KDo+0W9/VFxrleblBHyMycxWlhbp5/cftf9IzePb9RyqzP6jGjwmQqfcXSyvvIqN8s/exEQmqKj8wAFOXslWFZbnqk/mGL/963Z9I5ci1DlloOPnjIarUJmd7xj51znGKFZF8m/XE0i+d5c9rrcGBfEs0dhMTWxGmn+LJHO7YI9HJSUe7c73yO1WwGN+XL33SlBo3hnalsKRgNa0i3jggQdsT7LqjKsJPJ966ikb0JpyhFdeeUUjRoxQYmKivezaZ5995itoTkurygyZOo39rboz7yzOP/983X///ercuXO9AlrzmOrMcKDebS3Fnq2rtf372ep4/NlqlX6YygpytXnefxS9+BNlDqj9DgzNi8nOto5J81tAll+arQ27F2pol4tt9g/Nx1ats4vI6lpABgDNzSEHtKaw2DTVNTWtJitbrbKy0pYmVBs6dKgtETA1FrfccouGDatadXswTNGyKWuoz4q7avfee6/uuusuNSeRca0kV0StxVqVpYW1MqzVti38SKndB6pdz6pay/jU9vJUlGvj3DeV0X9kg8ZE6JhMrFngs+8CMJO5jdkna7uvSk+5svesVPd2w/327y7eZLslfLHmCd8+kxX8ccdn2rB7gUYcfrXDzwL1Fa1YO9+mu0FN5SqrlbXdl9tbqWxt0uHqE+SzRGPLTIvU9h1uv33mdlJihOLjIxQZ6ZLpcR/omIx0SlGCigxt+F361qx2M8wKOtOloHozV5YwK+CqmTYRX331lS0mNn3KGuLTTz+1bSSioqLsVt3rzPQ+M1niuoLg/Px832Z6t4W7iMgoJbTrqD1bf/bt85qauy0/KyFjb41lTZ7KClOEt89Av9z2NmxMhE6EK1JJcZnaVby3ntmUjuwsXq+UuA77fez2PT/aGtz2Sf4BTlbyUTq+y6Ua2mWCbzNdDrqmDtagTr8P2nPBgUWY+nWlaJdy/Obb3E6R/4rjfW3XZnnlUaZot9fcHTcoTp/OLfHbN+uLYh03sOpNT0yMSwP7xvod4/F49encYg395RiguTjkt2imCNiscDMf/19wwQV1HmfKBMxl1j7//HPb1uH555/3tYyorpk1l2fbn7ffflslJXtfmN99951dcPbll1/aK1QEUtfl4MJd+lG/0oYvXldCu05qldZZOcu/kKeyXG2PqOpQsH7Oa4pplaysY0+1t5M791bOss+V0LaDEtI7qyw/12ZtzX7XL6sbDzQmGtdhbY7VsuwPbGCbHNfeZlHdngp1SK5qwfTDtvcVG5WoHmkj/B63OX+p0lsfUavrgbm97z5TTxsT2UqtYvYfNCH4OquHVug7JXnbKFmp2qifbdut9qrqerDMO19xild319G1yg3SlKUYV+2/exVek/MtVpmq/o4WaY99Q2uyvrEuApzGVljk0ep1Fb7b6zdWasmyMqWmRKhzx2jddneutmS79eIjVYtvrhyfrMeey9ct03NtF4PPvirRm/8t1Hsv7+0Fev2VKZpwXY4G9ovV4P5xeuiZPBUVe3XJeXzyFs5XCkNtjnzmYD7Sv/baa22Jgbm+r6lZXbBggXbv3m37n5lFYmbR2FtvvaUTTjhBDz74oK677jpbU2uuLpGenm5XzZk2Eqa3rOmUULNcodq+Qau5RrFhyhBSUlpWc/A2hw+wi7y2LZqpyuICxbftoMNPmajohKo/UhWFeX51kZkDRtkX19aF/08VRfl2sZcJZtsPGlvvMdG42if1siUGq3PnqsxdpKTYdA3s+HvfQrGSioJaf0HNgrG8ks32OISXTFcnVXjLtFYrVKZSJSpZAzTMF3iawNSUJdRU5DW9EXZqgPzLS6rt0Fat0ALf7WX61n7tql6UKDQBC74v1chztvpum/6xxvjfJ+r5hzK0LcetTVv2BrymZdd7r7TXjVNz9fCzeerYPkpPP5Dua9lljDsjUbk73Zp23y5l76hU/z6x+vC1LGWkUXKA5sXltUveD45p73D99df7XdDgtddes1lYsxjMdDcw1/Y1x4wZM8ZepcLUzJpFYtVME14TkH7xxRe2DOHZZ5+13QtMX9nhw4fbNhIHYo456aSTbOBc34DWLAozwXLf8XcrMoaMREuR/iWdGloS909rGvsUEGIzt9b/wjwIf6aTQ5sea20pYX2umBUq1THGqB6TFBXp/KfDle4yzfrpwSb3vMM2oA1nBLQtEwFty0JA2/IQ0LYsBLRN63k3BXzmAAAA4CS6HIRflwMAAACgMZGhBQAAcJLHa4o6gzMuAiJDCwAAgLBGhhYAAMBJ1NCGHAEtAACAo4IU0JpxERAlBwAAAAhrZGgBAACcRMlByJGhBQAAQFgjQwsAAOB4ey3adoUSGVoAAACENTK0AAAATvJ6qrZgjIuAyNACAAAgrJGhBQAAcBJdDkKODC0AAADCGhlaAAAAJ9HlIOTI0AIAACCskaEFAABwEjW0IUeGFgAAAGGNDC0AAICTbAltMDK0zg/ZXJChBQAAQFgjQwsAAOAkamhDjgwtAAAAwhoZWgAAACd5POb/gjQuAiFDCwAAgLBGhhYAAMBJ1NCGHBlaAAAAhDUytAAAAE4iQxtyZGgBAAAQ1sjQAgAAOMljLxUWpHERCBlaAAAAhDUytAAAAA7yej12C8a4CIwMLQAAAMIaGVoAAACnuxEEo96VLgd1IkMLAACAsEaGFgAAwPFMKhnaUCJDCwAAgLBGhhYAAMBJHo/kCkJHAroc1IkMLQAAAMIaGVoAAAAnUUMbcmRoAQAAENbI0AIAADjI6/HIG4QaWq4UVjcCWgAAACdRchBylBwAAAAgrJGhBQAAcJK57K2LDG0okaEFAABAWCNDCwAA4HgmNRgXViBDWxcytAAAAAhrZGgBAAAc5PV45Q1CDa2XDG2dyNACAAAgrJGhBQAAcJK9AEIwami5sEJdyNACAAAgrJGhBQAAcBA1tKFHhhYAAABhjQwtAACAk6ihDbkWF9BWp+vd5aWNfSoIoUp3WWOfAkLI7a1o7FNAiBXs4T/0LUlBoadJfwRfqQrJG6RxEZDL21T/NQTJ5s2b1alTp8Y+DQAAcIg2bdqkjh07qqkoLS1V165dlZ2dHbSfkZmZqXXr1ikuLi5oPyMctbiA1uPxaOvWrUpMTJTL5VJLUVBQYAN58+JPSkpq7NNBCDDnLQ9z3vK01Dk3ocuePXuUlZWliIimtRzIBLXl5eVBGz8mJoZgNoAWV3Jg/uE3pXdzoWb+4LWkP3pgzlsi5rzlaYlznpycrKbIBJsEnKHXtN7WAAAAAAeJgBYAAABhjYC2hYiNjdXUqVPtV7QMzHnLw5y3PMw50EIXhQEAAKB5IUMLAACAsEZACwAAgLBGQAsAAICwRkALAACAsEZACwBAM8f6bzR3BLTwwx+9ljfXzHnLUVZWZr8WFxf7LgWO5i07O9t+NZd6Z77RnBHQwlq/fr0WLVpk/+gR4DR/P//8s+68805deOGFuueee+x14NG8rVq1ShMmTNDJJ5+sc845Rz/99JO9FDiar7Vr1yorK0unnnqqvW3mm6AWzRV/zaAff/xRAwcO1Jlnnqm5c+cS1DZzP/zwg44//nht2LDBZm9mzpyp6667TgUFBY19agjinA8dOlTJycn2tW6YOa/O2PJ6b55yc3PVoUMHfffddxo1apTdx5sYNFf8y27htm/frj//+c/q37+/jj32WF1zzTX68ssvCWqbqc2bN+uCCy7Q5ZdfrpdfflmzZs3S1VdfbbN31R9NonlZt26dzj33XDvPTzzxhO69916NGTNGmZmZ9upSRUVF9vWO5sVkYmNiYtSpUye99dZbWrNmjUaPHu33qRzQnBDQtnDmo+bIyEj78fOkSZPUo0cPG+BWB7V8PNW8fPXVVzZjc8UVV/jm9ne/+51KSkpsFg/Nz+LFi3XMMcfYjGzN1735NGbIkCE2c/vee+/Z/bzemw+Tie3bt6/atGmjjh076vnnn9fy5ct1xhln6LLLLtOMGTPsmxmguYhq7BNA4xo0aJDN2JgMbfV/0B555BEb1D788MP61a9+ZTO1ZuOjqvBn6ul+//vfq2vXrva22+22cx4dHW2DWjQ/Z511lo466ihlZGTY2w899JB9bT/wwANKT0/XvHnz7Jsa87H00Ucf3dinCweVl5fbT14WLlxo59iUFx133HE2kDVrJlq1amVf//xtR3PAv+IWrLqkoDqYNYYPH65rr71WRxxxhP1anam95ZZb9Omnnzbi2cIJZn7NwiDD/IfMZOfNx5ImsKnpySef5CPJZsK8fs0nL9XdDUzZyUcffWTLi8ybm2nTpqldu3aaM2dOY58qHP77HhcXp2HDhtk3roZJXpgyk7S0NE2ZMsXuI5hFc0GGtgXbt27O/AE0+8wfQMNkca6//npbg/Xf//5XF110USOdKYKh5n/ITHBbWVlpv7/jjjts5wPz8SSal4SEBBvUREVF+V7veXl5NnPfs2fPxj49BOHvu/n7bcpLPvjgA82ePVsff/yxfa2feOKJtrba1NcCzQEBbQtU/R+yfVUvBKsOas0fvfPOO88uKjF1eKYeC81nvqsDWbPl5+fbzM0///lP/eMf/9CCBQvUq1evkJ8rgj/nJitvVN//zDPP2G4HpiwBzWfOq29369ZNU6dOtbXzJqg19dTGZ599ptTU1EY8Y8BZLi9L2VscUysZHx9f5/3V/yTMIrGnnnpK8+fP5z92zXi+DdPSx6yCzsnJ0eeff25rq9G853zp0qV64YUX7GIhE9zULD1C85lzU27w17/+1fYeJimB5ozimRbABCom42a8/fbbOv/88/e7utW8q1+2bJkNbMxHVQSzzXu+q8sPTM/Kb775hmC2Bcy5ubDGf/7zH9v1wrzOCWab55ybYNZk5O+66y6CWTR/JkOL5svj8Xj/8Ic/eGNiYrz33HOP1+VyeV9++eV6PTY/Pz/o54emMd9vvfWWd+3atSE5RzSNOTfzvWPHjpCcI5rO33WguaLkoIXo16+fvSKY6VZg3q03tP4OzW++0Tww5y0Pcw7sRUDbjFUHpuarWeBjvu7Zs0fvvPOO7UWI5oX5bnmY85aHOQcCo4a2GTN/9MxiD9NL1lwFyryTN/WRptG6qZWsyaxyR3hjvlse5rzlYc6BwAhomynTiqm0tNRe7tIs/DBXgjLefPNNHXvssTr77LPtFYKM++67z14KsaKiwtfhAOGF+W55mPOWhzkH6kYf2mao+lKG5iox5p276SNbveLV9Bo1jbTNilhzWdsRI0bo66+/tt0Mqv84Irww3y0Pc97yMOfA/pGhbYZML9Fqppn2kiVL7Dt0077F/FE0lzo1bV5MA/3f/OY39qIJ1c22EX6Y75aHOW95mHNg/1gU1sx8++239nKG6enpdjOXPTS9CqdPn27ftZv6q1atWtV614/wxHy3PMx5y8OcAwdGQNvMmEUC5p28uTDC6tWrtXXrVv3f//2funfvrsLCQmVmZurII4+0H1ndeOONjX26OETMd8vDnLc8zDlwYAS0YcxMndnMO/Hi4mL7kZMRFRXl94fwlFNO0UsvvWSvImOuLmM+qrr11lvVs2fPRjx7HCzmu+Vhzlse5hxoGBaFhSmzctUU+5uPmv7f//t/evnll+3lLAcPHqxTTz1VY8eOtccdffTR9uOpjRs3asKECXYfF04IP8x3y8OctzzMOdBwFNmEoeXLl+vee++137/77ru2VUufPn1si5adO3fqt7/9re1NWP1HztRWmRoshCfmu+Vhzlse5hw4NAS0Yeb777+3787Nu3jzcdSjjz5q/wjefvvtOuecc2yz7auvvtrWUxnmHXv//v21Y8cOXz9C3sWHD+a75WHOWx7mHHCAqaFFeFi+fLk3Pj7eO3XqVHs7NzfXe/jhh3sXLlzo3bJli7dDhw7eiRMn+o5/6623vJs3b/bOnDnTPhbhhflueZjzloc5B5xBDW2YMKtbTzrpJHXp0kXTpk3z7TfX8l60aJHuvvtuW1/1xBNP2P2bN2/WBx98YHsUnnnmmY145mgI5rvlYc5bHuYccA4lB2HycdSQIUN01FFH2Wtzm8seGm3btlXHjh11xRVXaMCAAXrqqafsHzrjscces/VVAwcObOSzx8Fivlse5rzlYc4BhzV2ihj7991333mjo6O906ZN81ZWVnqfeuopb7t27bx/+tOffMecc845dt8999zjve+++7xXXHGFNzEx0btkyZJGPXccPOa75WHOWx7mHHAeJQdNnFkgYBYDTJ061d4eN26c/WoWCxhm8YC5hvc111yjTz75RHl5efYdv7mOt/mK8MJ8tzzMecvDnAPO48IKYaR6JWtBQYFef/11+8fvvPPO0yOPPGLvN3/04uLibEPu6mbcCF/Md8vDnLc8zDngDDK0YaS6LUtSUpL9g2eYP37mD91DDz2klJSURj5DOIn5bnmY85aHOQecQUAbpqr/+Jk/embxQEJCgq8pN5of5rvlYc5bHuYcaDgC2jD/4/e73/3ONuMeOnRoY58Ogoz5bnmY85aHOQcahhraZoCrxLQszHfLw5y3PMw5cHAIaAEAABDWuLACAAAAwhoBLQAAAMIaAS0AAADCGgEtAAAAwhoBLQAAAMIaAS0AAADCGgEtAAAAwhoBLQAAAMIaAS0AAADCGgEtAAAAwhoBLQAAAMIaAS0AAAAUzv4/N9VP0qxElToAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Generate a similarity matrix\n",
+    "similarity_matrix = cosine_similarity(embeddings_np)\n",
+    "\n",
+    "# Visualize the similarity matrix\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.imshow(similarity_matrix, cmap=\"viridis\")\n",
+    "plt.colorbar(label=\"Cosine Similarity\")\n",
+    "plt.title(\"Text Similarity Matrix\")\n",
+    "plt.xticks(range(len(texts)), [f\"Text {i+1}\" for i in range(len(texts))], rotation=45)\n",
+    "plt.yticks(range(len(texts)), [f\"Text {i+1}\" for i in range(len(texts))])\n",
+    "for i in range(len(texts)):\n",
+    "    for j in range(len(texts)):\n",
+    "        plt.text(\n",
+    "            j,\n",
+    "            i,\n",
+    "            f\"{similarity_matrix[i, j]:.2f}\",\n",
+    "            ha=\"center\",\n",
+    "            va=\"center\",\n",
+    "            color=\"white\" if similarity_matrix[i, j] < 0.7 else \"black\",\n",
+    "        )\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "025b5d5e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mlxomni",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "aiohttp>=3.11.11,<4",
     "rich>=13.9.4",
     "openai==1.66.3",
+    "mlx-embeddings==0.0.3"
 ]
 
 [project.urls]

--- a/src/mlx_omni_server/embeddings/__init__.py
+++ b/src/mlx_omni_server/embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""MLX Embeddings API implementation."""

--- a/src/mlx_omni_server/embeddings/embeddings_service.py
+++ b/src/mlx_omni_server/embeddings/embeddings_service.py
@@ -1,0 +1,179 @@
+import numpy as np
+import re
+import tiktoken
+from mlx_embeddings import load, generate
+from typing import Dict, List, Union, Any, Optional, Tuple
+from pathlib import Path
+import mlx.core as mx
+
+from ..utils.logger import logger
+from .schema import EmbeddingRequest, EmbeddingData, EmbeddingResponse, EmbeddingUsage
+
+
+class EmbeddingsService:
+    """Service for generating embeddings using MLX models (focused on BERT-like models)"""
+
+    def __init__(self):
+        # Map of loaded models for caching
+        self._models: Dict[str, Tuple[Any, Any]] = {}
+        # Default encoder for token counting
+        try:
+            self._default_tokenizer = tiktoken.get_encoding("cl100k_base")
+        except:
+            # Fallback to another common encoding if cl100k_base is not available
+            try:
+                self._default_tokenizer = tiktoken.get_encoding("p50k_base")
+            except:
+                logger.warning(
+                    "Could not load any tiktoken encoding, token counts may be inaccurate"
+                )
+                self._default_tokenizer = None
+
+    def _get_model(self, model_id: str) -> Tuple[Any, Any]:
+        """Get or load a model based on its ID"""
+        if model_id not in self._models:
+            logger.info(f"Loading embedding model: {model_id}")
+            try:
+                model, processor = load(model_id)
+                self._models[model_id] = (model, processor)
+            except Exception as e:
+                logger.error(f"Error loading embedding model {model_id}: {str(e)}")
+                raise RuntimeError(f"Failed to load embedding model: {str(e)}")
+
+        return self._models[model_id]
+
+    def _count_tokens(self, text: Union[str, List[str]]) -> int:
+        """Count tokens in input text"""
+        if self._default_tokenizer is None:
+            # If no tokenizer is available, use a simple approximation
+            if isinstance(text, str):
+                return len(text.split())
+            elif isinstance(text, list):
+                return sum(len(t.split()) for t in text)
+            return 0
+
+        try:
+            if isinstance(text, str):
+                return len(self._default_tokenizer.encode(text))
+            elif isinstance(text, list):
+                return sum(len(self._default_tokenizer.encode(t)) for t in text)
+        except Exception as e:
+            logger.warning(f"Error counting tokens: {str(e)}. Using fallback method.")
+            # Fallback to simple approximation
+            if isinstance(text, str):
+                return len(text.split())
+            elif isinstance(text, list):
+                return sum(len(t.split()) for t in text)
+        return 0
+
+    def _ensure_float_list(self, embedding) -> List[float]:
+        """Ensure embedding is a flat list of float values"""
+        if isinstance(embedding, list):
+            # Handle case where first element is itself a list or array
+            if len(embedding) > 0 and (
+                isinstance(embedding[0], list)
+                or isinstance(embedding[0], mx.array)
+                or isinstance(embedding[0], np.ndarray)
+            ):
+                return [float(x) for x in embedding[0]]
+            # Otherwise, convert each element to float
+            return [float(x) for x in embedding]
+        elif isinstance(embedding, mx.array):
+            # Ensure array is 1D
+            if embedding.ndim > 1:
+                embedding = embedding.reshape(-1)
+            return [float(x) for x in embedding.tolist()]
+        elif isinstance(embedding, np.ndarray):
+            # Ensure array is 1D
+            if embedding.ndim > 1:
+                embedding = embedding.reshape(-1)
+            return [float(x) for x in embedding.tolist()]
+        else:
+            # Handle any other unexpected type
+            return [float(x) for x in list(embedding)]
+
+    def _get_bert_embeddings(self, model, processor, text):
+        """Extract embeddings specifically for BERT-like models"""
+        # Use proper encode method - processor may have different method names
+        encode_method = getattr(processor, "encode", None)
+        if encode_method is None:
+            encode_method = getattr(processor, "batch_encode_plus", None)
+
+        if encode_method:
+            # Use encode or batch_encode_plus
+            input_ids = encode_method(text, return_tensors="mlx")
+
+            # Handle different input formats
+            if isinstance(input_ids, dict):
+                outputs = model(**input_ids)
+            else:
+                outputs = model(input_ids)
+
+            # Extract embeddings based on model output structure
+            if hasattr(outputs, "last_hidden_state"):
+                # For models like BERT, MiniLM
+                # Check if model is likely MiniLM (which typically uses CLS token)
+                if "minilm" in model_id.lower():
+                    # MiniLM models typically use the CLS token (first token)
+                    return outputs.last_hidden_state[:, 0, :]
+                else:
+                    # Other BERT models might use mean pooling
+                    return outputs.last_hidden_state.mean(axis=1)
+            else:
+                # Last resort, assume the output itself is the embedding
+                return outputs
+
+        raise ValueError(f"Could not determine how to extract embeddings from model")
+
+    def generate_embeddings(self, request: EmbeddingRequest) -> EmbeddingResponse:
+        """Generate embeddings based on the request"""
+        model_id = request.model
+        model, processor = self._get_model(model_id)
+
+        # Handle both string and list of strings
+        inputs = request.input if isinstance(request.input, list) else [request.input]
+
+        # Count tokens for usage info
+        token_count = self._count_tokens(inputs)
+
+        # Generate embeddings for all inputs
+        embeddings = []
+        for idx, text in enumerate(inputs):
+            try:
+                # Generate embedding using the model
+                try:
+                    # First try the specific BERT extraction method
+                    embedding = self._get_bert_embeddings(model, processor, text)
+                except Exception as e:
+                    logger.debug(
+                        f"Failed with BERT method: {str(e)}. Trying general generate() function."
+                    )
+                    # Fall back to the generate function
+                    output = generate(model, processor, text)
+                    if hasattr(output, "last_hidden_state"):
+                        embedding = output.last_hidden_state[:, 0, :]
+                    else:
+                        embedding = output
+
+                # Convert to list of floats with proper formatting
+                embedding_list = self._ensure_float_list(embedding)
+
+                # Create embedding data
+                embedding_data = EmbeddingData(
+                    embedding=embedding_list,
+                    index=idx,
+                )
+                embeddings.append(embedding_data)
+
+            except Exception as e:
+                logger.error(f"Error generating embedding: {str(e)}", exc_info=True)
+                raise RuntimeError(f"Failed to generate embedding: {str(e)}")
+
+        # Create the full response
+        response = EmbeddingResponse(
+            data=embeddings,
+            model=model_id,
+            usage=EmbeddingUsage(prompt_tokens=token_count, total_tokens=token_count),
+        )
+
+        return response

--- a/src/mlx_omni_server/embeddings/router.py
+++ b/src/mlx_omni_server/embeddings/router.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException
+
+from .embeddings_service import EmbeddingsService
+from .schema import EmbeddingRequest, EmbeddingResponse
+
+router = APIRouter(tags=["embeddings"])
+embeddings_service = EmbeddingsService()
+
+
+@router.post("/embeddings", response_model=EmbeddingResponse)
+@router.post("/v1/embeddings", response_model=EmbeddingResponse)
+async def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
+    """Generate embeddings for text input.
+
+    This endpoint generates vector representations of input text,
+    which can be used for semantic search, clustering, and other NLP tasks.
+    """
+    try:
+        return embeddings_service.generate_embeddings(request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/mlx_omni_server/embeddings/schema.py
+++ b/src/mlx_omni_server/embeddings/schema.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ModelType(str, Enum):
+    BERT = "bert"
+
+
+class EmbeddingRequest(BaseModel):
+    model: str = Field(..., description="ID of the model to use")
+    input: Union[str, List[str]] = Field(
+        ..., description="Input text to get embeddings for"
+    )
+    encoding_format: Optional[str] = Field(
+        "float", description="The format of the embeddings"
+    )
+    user: Optional[str] = None
+    dimensions: Optional[int] = None
+
+    # Allow any additional fields
+    class Config:
+        extra = "allow"  # This allows additional fields not defined in the model
+
+    def get_extra_params(self) -> Dict[str, Any]:
+        """Get all extra parameters that aren't part of the standard OpenAI API."""
+        standard_fields = {"model", "input", "encoding_format", "user", "dimensions"}
+        return {k: v for k, v in self.model_dump().items() if k not in standard_fields}
+
+
+class EmbeddingData(BaseModel):
+    object: str = "embedding"
+    embedding: List[float]
+    index: int
+
+
+class EmbeddingUsage(BaseModel):
+    prompt_tokens: int
+    total_tokens: int
+
+
+class EmbeddingResponse(BaseModel):
+    object: str = "list"
+    data: List[EmbeddingData]
+    model: str
+    usage: EmbeddingUsage

--- a/src/mlx_omni_server/routers.py
+++ b/src/mlx_omni_server/routers.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from .chat import router as chat_router
 from .chat.models import models
+from .embeddings import router as embeddings_router
 from .images import images
 from .stt import stt as stt_router
 from .tts import tts as tts_router
@@ -12,3 +13,4 @@ api_router.include_router(tts_router.router)
 api_router.include_router(models.router)
 api_router.include_router(images.router)
 api_router.include_router(chat_router.router)
+api_router.include_router(embeddings_router.router)


### PR DESCRIPTION
I added support for `v1/embeddings` endpoint using [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) library!

- Created `embeddings` package with the following components:
  - `__init__.py`: Basic module documentation.
  - `embeddings_service.py`: Service class for generating embeddings using MLX models, including methods for model loading, token counting, and embedding extraction.
  - `router.py`: FastAPI router for handling embedding generation requests.
  - `schema.py`: Pydantic models for request and response validation.
- Integrated the embeddings router into the main API router.
- - Added `mlx-embeddings` dependency to `pyproject.toml`.


example
```python
from openai import OpenAI
client = OpenAI(
    base_url="http://localhost:10240/v1",  # Point to local server
    api_key="not-needed",  # API key is not required for local server
)
# Generate embedding for a single text
response = client.embeddings.create(
    model="mlx-community/all-MiniLM-L6-v2-4bit", input="I like reading"
)
```

