### PR TITLE
Adding `chat_template_config` params and support switching Qwen3 thinking mode

### DIFF
--- a/src/mlx_omni_server/chat/text_models.py
+++ b/src/mlx_omni_server/chat/text_models.py
@@ -1,8 +1,15 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, Optional
+from typing import Any, Dict, Generator, Optional, TypedDict
 
 from .schema import ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse
+
+
+class GenerationParams(TypedDict):
+    sampler_kwargs: Dict[str, Any]
+    model_kwargs: Dict[str, Any]
+    generate_kwargs: Dict[str, Any]
+    template_kwargs: Dict[str, Any]
 
 
 @dataclass


### PR DESCRIPTION
## Description

Additional config for `apply_chat_template` just like `mlx_lm.generate`, support switching between thinking mode and non-thinking mode when using Qwen3 models

```bash
mlx_lm.generate --model 'mlx-community/Qwen3-4B-4bit' --prompt 'Hello' --chat-template-config '{"enable_thinking":false}'
```
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/95066dab-1338-4178-8fd1-57208532343e" />


## Feature

- Fixed the sampler params like `top_k` do not get passed to :func:`make_sampler` as it is filtered by :func:`_get_generation_params` 
- Adding `chat_template_config` and some other quick reasoning params

## Examples

### Using `chat_template_config`
```bash
curl http://localhost:10240/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/Qwen3-4B-4bit",
    "messages": [
      {
        "role": "user",
        "content": "Hello"
      }
    ],
    "chat_template_config": {"enable_thinking":false}
  }'
```
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/6a475bb7-a49c-40c0-bd25-7976a1b0eaa0" />


### Using `enable_thinking`

> Priority `chat_template_config.enable_thinking` > `enable_thinking`

```bash
curl http://localhost:10240/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/Qwen3-4B-4bit",
    "messages": [
      {
        "role": "user",
        "content": "Hello"
      }
    ],
    "enable_thinking": false
  }'
```
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/7f76e1b4-ae66-4ef6-9025-e61d1b9458e3" />

```bash
curl http://localhost:10240/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/Qwen3-4B-4bit",
    "messages": [
      {
        "role": "user",
        "content": "Hello"
      }
    ],
    "enable_thinking": false,
    "chat_template_config": {"enable_thinking":true}
  }'
```
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/415a8974-2ecb-4e8f-873c-a8d3fd2eb77b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of generation parameters by grouping them into structured categories, enhancing modularity and clarity in parameter management.
- **Style**
	- Added detailed logging for debugging parameter values during the generation process.
- **Chores**
	- Introduced a new type definition to improve type safety and code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->