### PR TITLE
Add mlx-omni-server Homebrew Formula (v0.4.3)

### DIFF
--- a/Formula/mlx-omni-server.rb
+++ b/Formula/mlx-omni-server.rb
@@ -1,0 +1,56 @@
+class MlxOmniServer < Formula
+  include Language::Python::Virtualenv
+
+  desc "OpenAI-compatible API server powered by Apple's MLX framework"
+  homepage "https://github.com/madroidmaq/mlx-omni-server"
+  url "https://github.com/madroidmaq/mlx-omni-server/archive/refs/tags/v0.4.3.tar.gz"
+  # To get the actual SHA256 hash, download the package and run:
+  # curl -L -o mlx-omni-server-0.4.3.tar.gz https://github.com/madroidmaq/mlx-omni-server/archive/refs/tags/v0.4.3.tar.gz
+  # shasum -a 256 mlx-omni-server-0.4.3.tar.gz
+  sha256 "8d39e28aa9249f102accfb8a9f09d44adf1ca2738b1338335cfd2622796a88b6"
+  license "MIT"
+
+  depends_on "python@3.11"
+  depends_on :macos
+
+  # This formula installs the following key dependencies from PyPI:
+  # - fastapi: Web framework for building APIs
+  # - uvicorn: ASGI server
+  # - pydantic: Data validation
+  # - mlx-lm: Language model support using MLX
+  # - mlx-whisper: Speech-to-text using MLX
+  # - f5-tts-mlx: Text-to-speech using MLX
+  # - mflux: Image generation using MLX
+  # - mlx-embeddings: Text embeddings using MLX
+
+  def install
+    # Install all dependencies from pyproject.toml
+    system "pip3", "install", "--prefix=#{libexec}", "."
+    bin.install Dir["#{libexec}/bin/*"]
+    bin.env_script_all_files(libexec/"bin", PATH: "#{libexec}/bin:$PATH", PYTHONPATH: "#{libexec}/lib/python3.11/site-packages")
+  end
+
+  # Only allow installation on Apple Silicon Macs
+  pour_bottle? do
+    reason "MLX Omni Server requires Apple Silicon (M-series) chips"
+    satisfy { Hardware::CPU.arm? }
+  end
+
+  def caveats
+    <<~EOS
+      MLX Omni Server is designed specifically for Apple Silicon (M-series) chips.
+      It will not work on Intel-based Macs.
+
+      To start the server:
+        mlx-omni-server
+
+      The server will be available at:
+        http://localhost:10240
+    EOS
+  end
+
+  test do
+    # Add a basic test to verify the installation
+    assert_match "MLX Omni Server", shell_output("#{bin}/mlx-omni-server --help")
+  end
+end

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,106 @@
+# Homebrew Formula for MLX Omni Server
+
+This document provides instructions for testing and submitting the MLX Omni Server formula to Homebrew.
+
+## Prerequisites
+
+- Homebrew installed on your Mac
+- Apple Silicon Mac (M-series chip)
+- Git
+
+## Testing the Formula Locally
+
+1. **Get the actual SHA256 hash for the package**:
+
+   ```bash
+   curl -L -o mlx-omni-server-0.4.3.tar.gz https://github.com/madroidmaq/mlx-omni-server/archive/refs/tags/v0.4.3.tar.gz
+   shasum -a 256 mlx-omni-server-0.4.3.tar.gz
+   ```
+
+   Update the `sha256` value in the formula with the actual hash.
+
+2. **Install the formula locally**:
+
+   ```bash
+   brew install --build-from-source ./mlx-omni-server.rb
+   ```
+
+3. **Test the installation**:
+
+   ```bash
+   mlx-omni-server --help
+   ```
+
+   You should see the help message for MLX Omni Server.
+
+## Submitting to Homebrew
+
+There are two main ways to submit your formula to Homebrew:
+
+### Option 1: Submit to Homebrew Core (Official Repository)
+
+1. **Fork the Homebrew Core repository**:
+
+   ```bash
+   brew tap homebrew/core
+   cd "$(brew --repository homebrew/core)"
+   git remote add me https://github.com/YOUR_USERNAME/homebrew-core
+   git checkout -b mlx-omni-server
+   ```
+
+2. **Copy your formula to the Formula directory**:
+
+   ```bash
+   cp /path/to/mlx-omni-server.rb Formula/m/mlx-omni-server.rb
+   ```
+
+3. **Test the formula**:
+
+   ```bash
+   brew audit --new-formula Formula/m/mlx-omni-server.rb
+   brew style Formula/m/mlx-omni-server.rb
+   brew install --build-from-source Formula/m/mlx-omni-server.rb
+   brew test Formula/m/mlx-omni-server.rb
+   ```
+
+4. **Commit and push your changes**:
+
+   ```bash
+   git add Formula/m/mlx-omni-server.rb
+   git commit -m "mlx-omni-server: new formula"
+   git push me mlx-omni-server
+   ```
+
+5. **Create a pull request** on the [Homebrew Core repository](https://github.com/Homebrew/homebrew-core).
+
+### Option 2: Create Your Own Tap (Recommended for Project-Specific Formulas)
+
+1. **Create a new GitHub repository** named `homebrew-tap` (or any name you prefer).
+
+2. **Add your formula to the repository**:
+
+   ```bash
+   mkdir -p Formula
+   cp mlx-omni-server.rb Formula/
+   git add Formula/mlx-omni-server.rb
+   git commit -m "Add mlx-omni-server formula"
+   git push
+   ```
+
+3. **Tap your repository**:
+
+   ```bash
+   brew tap YOUR_USERNAME/tap
+   ```
+
+4. **Install your formula**:
+
+   ```bash
+   brew install YOUR_USERNAME/tap/mlx-omni-server
+   ```
+
+## Additional Resources
+
+- [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Homebrew Python for Formula Authors](https://docs.brew.sh/Python-for-Formula-Authors)
+- [Homebrew Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)


### PR DESCRIPTION
## Add `mlx-omni-server` Homebrew Formula (v0.4.3)

Demo [here](https://github.com/seemueller-io/homebrew-tap/tree/main)

### What’s Changed
- Introduces a new Homebrew formula for **MLX Omni Server** (v0.4.3), an OpenAI-compatible API server powered by Apple’s MLX framework.
- Defines URL, SHA256 checksum, license, and metadata.
- Declares dependencies on Python 3.11 and macOS (Apple Silicon only).
- Installs Python virtualenv, associated scripts, and environment wrappers.
- Provides a simple `--help` test to verify installation.

### Why
This formula lets users easily install and manage MLX Omni Server via Homebrew on M-series Macs, simplifying deployment of:
- FastAPI backend  
- Uvicorn ASGI server  
- MLX-based language, speech, TTS, embeddings, and image-generation components  

### Testing
1. Generated the SHA256 checksum for the source tarball.
2. Ran local audits and style checks:
```shell script
brew audit --new-formula ./mlx-omni-server.rb
   brew style  ./mlx-omni-server.rb
```

3. Installed from source and verified the help output:
```shell script
brew install --build-from-source ./mlx-omni-server.rb
   mlx-omni-server --help
```

4. Confirmed the test block passes:
```shell script
make test
```


### Caveats
- **Apple Silicon only** — the formula will refuse to pour on Intel-based Macs.
- After installation, launch the server with:
```shell script
mlx-omni-server
```

  then visit `http://localhost:10240`.

---

Please review and let me know if any adjustments are needed before merging!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Homebrew formula for installing the MLX Omni Server, compatible with Apple Silicon Macs.

- **Documentation**
  - Introduced a guide with step-by-step instructions for testing and submitting the Homebrew formula, including prerequisites and troubleshooting tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->