### PR TITLE
Clip logprobs to -100 to avoid JSON encoder errors

### DIFF
--- a/src/mlx_omni_server/chat/mlx/mlx_model.py
+++ b/src/mlx_omni_server/chat/mlx/mlx_model.py
@@ -130,7 +130,7 @@ class MLXModel(BaseTextModel):
         if top_k is not None:
             # Get indices of top_k tokens
             top_indices = mx.argpartition(-current_logprobs, kth=top_k - 1)[:top_k]
-            top_probs = current_logprobs[top_indices]
+            top_probs = mx.clip(current_logprobs[top_indices], a_min=-100, a_max=None)
 
             # Create detailed token information for each top token
             for idx, logprob in zip(top_indices.tolist(), top_probs.tolist()):

--- a/src/mlx_omni_server/chat/mlx/mlx_model.py
+++ b/src/mlx_omni_server/chat/mlx/mlx_model.py
@@ -115,7 +115,9 @@ class MLXModel(BaseTextModel):
 
         # Get current token info
         token_str = tokenizer.decode([current_token])
-        token_logprob = current_logprobs[current_token].item()
+        token_logprob = mx.clip(
+            current_logprobs[current_token], a_min=-100, a_max=None
+        ).item()
         token_bytes = token_str.encode("utf-8")
 
         # Base token info


### PR DESCRIPTION
Models can return a -inf logprob for tokens that they are certain are not correct, e.g. if `top_logprobs` is larger than the possible tokens allowed in a position in a structured output.

Unfortunately the JSON spec doesn't allow inf or NaN values for number fields, so this results in an encoder error:

> ValueError: Out of range float values are not JSON compliant: -inf

This change clips logprobs to a minimum of -100 to avoid the error, which is the same behaviour as OpenAI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of extreme negative log probabilities for AI-generated responses, ensuring more stable and consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->