### PR TITLE
fix: support Qwen3-Embedding models via text_embeds attribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ dependencies = [
     "numba>=0.57.0",
     # images
     "mflux>=0.11.0,<0.12",
-    # embeddings
-    "mlx-embeddings>=0.0.3",
+    # embeddings (>=0.0.4 for Qwen3-Embedding support)
+    "mlx-embeddings>=0.0.4",
 ]
 
 [project.urls]

--- a/src/mlx_omni_server/embeddings/embeddings_service.py
+++ b/src/mlx_omni_server/embeddings/embeddings_service.py
@@ -151,7 +151,11 @@ class EmbeddingsService:
                     )
                     # Fall back to the generate function
                     output = generate(model, processor, text)
-                    if hasattr(output, "last_hidden_state"):
+                    # Priority: text_embeds (Qwen3-Embedding, already pooled/normalized)
+                    # > last_hidden_state (BERT-style, use CLS token) > raw output
+                    if hasattr(output, "text_embeds") and output.text_embeds is not None:
+                        embedding = output.text_embeds
+                    elif hasattr(output, "last_hidden_state"):
                         embedding = output.last_hidden_state[:, 0, :]
                     else:
                         embedding = output


### PR DESCRIPTION
## Summary

Qwen3-Embedding models (0.6B/4B/8B) are currently the #1 embedding models on the MTEB multilingual leaderboard (score 70.58). However, they don't work correctly with mlx-omni-server because these models return pooled embeddings via the `text_embeds` attribute, not `last_hidden_state`.

The current code extracts the CLS token from `last_hidden_state[:, 0, :]` which produces near-zero cosine similarity for Qwen3-Embedding outputs (essentially garbage embeddings).

## Changes

- Prioritize `text_embeds` attribute when available (used by Qwen3-Embedding models with proper last-token pooling + normalization)
- Fall back to `last_hidden_state[:, 0, :]` for BERT-style models (backward compatible)
- Bump `mlx-embeddings>=0.0.4` (required for Qwen3 model architecture support)

## Testing

Tested with `mlx-community/Qwen3-Embedding-8B-4bit-DWQ`:

| Test | Result |
|------|--------|
| Embedding dimension | 4096 ✓ |
| Similar sentences (cat/feline) | 0.87 cosine similarity ✓ |
| Dissimilar sentences (cat/stock) | 0.62 cosine similarity ✓ |

Before this fix, similar sentences had ~0.0 similarity due to wrong pooling.

## References

- [Qwen3-Embedding announcement](https://qwenlm.github.io/blog/qwen3-embedding/)
- [mlx-embeddings Qwen3 implementation](https://github.com/Blaizzy/mlx-embeddings/blob/main/src/mlx_embeddings/models/qwen3.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mlx-embeddings dependency to version >=0.0.4 for Qwen3-Embedding model support and compatibility

* **Bug Fixes**
  * Enhanced embedding extraction logic to intelligently prioritize available model outputs with improved fallback handling for better compatibility across different embedding model architectures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->