### PR TITLE
Fix caching which was causing wrong tokens to be generated

### DIFF
--- a/src/mlx_omni_server/chat/mlx/chat_generator.py
+++ b/src/mlx_omni_server/chat/mlx/chat_generator.py
@@ -452,10 +452,16 @@ class ChatGenerator:
                 draft_model=self.model.draft_model,
                 **mlx_kwargs,
             ):
+                generated_tokens.append(response.token)
+
+                # Extend cache with generated tokens if caching is enabled
+                # We have to cache the token immediately because the stream
+                # Could be interrupted by the client
+                if enable_prompt_cache:
+                    self.prompt_cache.append_token(response.token)
+
                 if response.finish_reason is not None:
                     break
-
-                generated_tokens.append(response.token)
 
                 # Record first token time if this is the first token
                 if first_token_time is None:
@@ -506,11 +512,6 @@ class ChatGenerator:
                     logprobs=logprobs,
                     from_draft=response.from_draft,
                 )
-
-            # Extend cache with generated tokens if caching is enabled
-            if enable_prompt_cache and generated_tokens:
-                self.prompt_cache.extend_completion_cache(generated_tokens)
-
         except Exception as e:
-            logger.error(f"Error during stream generation: {e}")
+            logger.exception(f"Error during stream generation: {e}")
             raise RuntimeError(f"Stream generation failed: {e}")

--- a/src/mlx_omni_server/chat/mlx/model_types.py
+++ b/src/mlx_omni_server/chat/mlx/model_types.py
@@ -60,7 +60,7 @@ def load_mlx_model(
 
                 # Check if vocabulary sizes match
                 if draft_tokenizer.vocab_size != tokenizer.vocab_size:
-                    logger.warn(
+                    logger.warning(
                         f"Draft model({draft_model_id}) tokenizer does not match model tokenizer."
                     )
 

--- a/src/mlx_omni_server/chat/mlx/prompt_cache.py
+++ b/src/mlx_omni_server/chat/mlx/prompt_cache.py
@@ -63,6 +63,9 @@ class PromptCache:
     def extend_completion_cache(self, completion_tokens):
         self.tokens.extend(completion_tokens)
 
+    def append_token(self, token):
+        self.tokens.append(token)
+
     def reset_prompt_cache(self, model: MLXModel, prompt):
         logger.debug("*** Resetting cache. ***")
         self.model_key = model.model_id
@@ -87,9 +90,11 @@ class PromptCache:
             prompt (List[int]): The tokenized new prompt.
 
         Returns:
-            List[int]: The suffix of the prompt that actually needs to be processed
-                       by the model. This will be the full prompt if the cache is
-                       reset or cannot be effectively used.
+            Tuple[List[int], int]: A tuple where:
+                - The first element is the suffix of the prompt that actually needs
+                to be processed by the model
+                - The second element is the length of the cached prefix that was
+                successfully reused (0 if cache was reset)
         """
         cache_len = len(self.tokens)
         prompt_len = len(prompt)
@@ -97,19 +102,28 @@ class PromptCache:
         prompt_cached_tokens = 0
 
         # Leave at least one token in the prompt
-        com_prefix_len = min(com_prefix_len, len(prompt) - 1)
+        com_prefix_len = min(com_prefix_len, len(prompt))
 
         # Condition 1: Model changed or no common prefix at all. Reset cache.
         if self.model_key != model.model_id or com_prefix_len == 0:
             self.reset_prompt_cache(model, prompt)
-
         # Condition 2: Common prefix exists and matches cache length. Process suffix.
         elif com_prefix_len == cache_len:
+            # When prompt exactly matches cache length, we're processing a complete reuse
+            # of the cached prefix, so we only need to reprocess the very last token
+            # The cached_prefix_length represents the full common prefix length
+            # which is used for tracking purposes but we don't extend the cache here
             logger.debug(
                 f"*** Cache is prefix of prompt (cache_len: {cache_len}, prompt_len: {prompt_len}). Processing suffix. ***"
             )
-            prompt = prompt[com_prefix_len:]
-            self.tokens.extend(prompt)
+            if com_prefix_len == prompt_len:
+                # Reuse same prompt - only need to process the last token
+                # (triggers reprocessing of last exchange but caches all previous tokens)
+                prompt = prompt[-1:]  # feed last token only
+            else:
+                # Normal case - process suffix that wasn't cached
+                prompt = prompt[com_prefix_len:]
+                self.tokens.extend(prompt)
             prompt_cached_tokens = com_prefix_len
 
         # Condition 3: Common prefix exists but is shorter than cache length. Attempt trim.
@@ -118,16 +132,57 @@ class PromptCache:
                 f"*** Common prefix ({com_prefix_len}) shorter than cache ({cache_len}). Attempting trim. ***"
             )
 
-            if can_trim_prompt_cache(self.cache):
-                num_to_trim = cache_len - com_prefix_len
-                logger.debug(f"    Trimming {num_to_trim} tokens from cache.")
-                trim_prompt_cache(self.cache, num_to_trim)
-                self.tokens = self.tokens[:com_prefix_len]
-                prompt = prompt[com_prefix_len:]
-                self.tokens.extend(prompt)
-                prompt_cached_tokens = com_prefix_len
+            # Back off 1 token: ensures last matching token is *not* in cache
+            # Model re-sees transition (e.g., 'assistant' -> '\n') -> correct tool calls
+            #
+            # Example 1: Qwen with '\n' after 'assistant'
+            #   Cache:  [... 'assistant' '\n' '<tool_call>']
+            #   Prompt: [... 'assistant' '\n' '<tool_call>']
+            #   com_prefix_len = 5 (includes '\n')
+            #   safe_len = 4 -> cache ends at 'assistant'
+            #   Prompt fed: '\n' '<tool_call>' -> model sees 'assistant' -> '\n' -> emits <tool_call>
+            #
+            # Example 2: No whitespace (hypothetical model)
+            #   Cache:  [... '<|assistant|>']
+            #   Prompt: [... '<|assistant|>' '<tool_call>']
+            #   com_prefix_len = 4
+            #   safe_len = 3 -> cache ends before role marker
+            #   Prompt fed: '<|assistant|>' '<tool_call>' -> full transition
+            #
+            # Example 3: JSON mode
+            #   Cache:  ['{' '"response":' '"']
+            #   Prompt: ['{' '"response":' '"' '{' '"answer":' '42' '}']
+            #   com_prefix_len = 3
+            #   safe_len = 2 -> cache ends at '"response":'
+            #   Prompt fed: '"' '{' ... -> model sees ':' -> '{'-> valid JSON
+
+            safe_len = max(0, com_prefix_len - 1)
+            num_trim = cache_len - safe_len
+
+            # Trim the token cache
+            self.tokens = self.tokens[:safe_len]
+
+            # Attempt to trim the prompt cache if possible
+            if num_trim > 0 and can_trim_prompt_cache(self.cache):
+                trimmed_count = trim_prompt_cache(self.cache, num_trim)
+                if not trimmed_count:
+                    logger.debug("Trimming failed. Resetting cache")
+                    self.reset_prompt_cache(model, prompt)
+                    return prompt, prompt_cached_tokens
+
+                # Determine the new prompt based on what's left in cache
+                prompt_suffix = prompt[safe_len:]
+
+                if prompt_suffix:
+                    # Extend the tokens with the suffix that was not cached
+                    prompt = prompt_suffix
+                    self.tokens.extend(prompt_suffix)
+                elif safe_len > 0:
+                    # No suffix to work with - use the last cached token
+                    prompt = self.tokens[-1:]
+
+                prompt_cached_tokens = safe_len
             else:
-                logger.debug("    Cache cannot be trimmed. Resetting cache.")
                 self.reset_prompt_cache(model, prompt)
 
         # This case should logically not be reached if com_prefix_len <= cache_len

--- a/uv.lock
+++ b/uv.lock
@@ -2471,7 +2471,7 @@ wheels = [
 
 [[package]]
 name = "mlx-omni-server"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "f5-tts-mlx" },


### PR DESCRIPTION
This change improves the caching mechanism which appears to be based mostly on the mlx-lm caching code (will submit a PR there as well). In its original conception, the caching code contains very subtle bugs which may only appear as issues in very specific cases document here:

## Cache corruption bugs
### 1. When regenerating a prompt:
This  bug can be demonstrated simply with two overlapping sessions. When triggered, this will cause issues with the remainder of the session as the cache will be corrupted.

To reproduce, simply start two chat session with a model. For instance, using qwen3 coder:
#### In session one:
user: "Hi there!"
assistant: Hi, nice to meet you! ...

#### In session two:
user: "Hi there!" <- this causes cached to be used
assistant: <|endoftext|>This is an example of a conversation between two people.

The chat completion actually shows the `<|endoftext|>` token. This is because the cache is being used to generate a completion prompt where the prompt has been trimmed in the wrong place.

### 2. When interrupting a streaming completion:
The bug can be demonstrated by cancelling a streaming completion. 

#### In session one:
user: "Write a high performance hash table in C++ for efficient string handling."
assistant: [long stream of tokens] "Okay, I'll write a fa"

cancel the stream.

#### In session two:
user: "Write a high performance hash table in C++ for efficient string handling."
assistant: [wrong tokens, usually starts where ever the last assistant stream was cancelled] "st hang table for you..."

Because the caching mechanism only writes to the [local token cache](https://github.com/madroidmaq/mlx-omni-server/blob/f11fda844f88db06ab0cbc95213a3dcc2b3c1b08/src/mlx_omni_server/chat/mlx/chat_generator.py#L511) when the completion successfully ends, the token local cache no longer knows where to trim the internal mlx cache.

## Fixes
This PR fixes both issues with the local cache token drift. 
1. It properly handles resuming from a common prefix, where the mlx cache expects at least one token for completion in the prompt.
2. It handles the case where a generation stream may get interrupted by always writing token as they are generated to the local token cache.
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced prompt caching mechanism with immediate token caching and improved boundary handling for better performance.

* **Bug Fixes**
  * Improved error reporting and exception logging during stream generation for better diagnostics.

* **Chores**
  * Updated deprecated logging methods to current standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->