### PR TITLE
feat: Add support for local model paths

### DIFF
--- a/src/mlx_omni_server/chat/mlx/model_types.py
+++ b/src/mlx_omni_server/chat/mlx/model_types.py
@@ -79,6 +79,11 @@ def load_mlx_model(
 
     model_id = model_id.strip()
 
+    # Expand ~ for local paths before passing to load()
+    local_path = Path(model_id).expanduser()
+    if local_path.exists() and local_path.is_dir():
+        model_id = str(local_path)
+
     try:
         # Load the main model
         model, tokenizer = load(
@@ -97,6 +102,10 @@ def load_mlx_model(
         draft_model = None
         draft_tokenizer = None
         if draft_model_id:
+            # Expand ~ for local draft model paths
+            draft_local = Path(draft_model_id).expanduser()
+            if draft_local.exists() and draft_local.is_dir():
+                draft_model_id = str(draft_local)
             try:
                 draft_model, draft_tokenizer = load(
                     draft_model_id,


### PR DESCRIPTION
## Summary

This PR adds support for loading models from local filesystem paths, in addition to HuggingFace repo IDs.

**Problem:** Currently, users cannot load locally fused or custom-trained models. For example, after running `mlx_lm.fuse` to merge a LoRA adapter into a base model, the resulting model cannot be served because mlx-omni-server only accepts HuggingFace repo IDs.

**Solution:** Modify `get_model_path()` to first check if the provided `model_id` is a valid local directory containing a `config.json` file. If so, use it directly. Otherwise, fall back to HuggingFace resolution.

## Changes

- Modified `get_model_path()` in `src/mlx_omni_server/chat/mlx/model_types.py`
- Backward compatible - existing HuggingFace repo IDs continue to work

## Example Usage

```python
# Local path (new functionality)
response = client.chat.completions.create(
    model="/path/to/my/fused-model",
    messages=[{"role": "user", "content": "Hello"}]
)

# HuggingFace repo ID (still works)
response = client.chat.completions.create(
    model="mlx-community/Qwen2.5-14B-Instruct-4bit",
    messages=[{"role": "user", "content": "Hello"}]
)
```

## Testing

Tested locally with a fused LoRA model created via `mlx_lm.fuse`. The model loads correctly and responds to chat completions with tool calling.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model loading now accepts local model directories (with config) and expands user home paths (~) before resolving.
  * Draft model paths are also expanded and respected when provided.
* **Compatibility**
  * Improved resolution logic to maintain compatibility with both newer and legacy model resolution methods while preserving the public interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->