### PR TITLE
tools: Qwen3MoeToolParser support <tool_call>{json}</tool_call>

### DIFF
--- a/src/mlx_omni_server/chat/mlx/tools/qwen3_moe_tools_parser.py
+++ b/src/mlx_omni_server/chat/mlx/tools/qwen3_moe_tools_parser.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from ....utils.logger import logger
 from ..core_types import ToolCall
-from .base_tools import BaseToolParser
+from .base_tools import BaseToolParser, extract_tools
 
 
 class Qwen3MoeToolParser(BaseToolParser):
@@ -133,9 +133,16 @@ class Qwen3MoeToolParser(BaseToolParser):
                 logger.debug("parse_tools: text doesn't match strict format")
                 return None
 
+            # First: prefer <tool_call>{"name":...,"arguments":...}</tool_call> JSON blocks.
+            # Qwen3 models frequently emit the HuggingFace unified format, not <function=...> tags.
+            parsed = extract_tools(text)
+            if parsed:
+                logger.debug(f"parse_tools: extracted {len(parsed)} tool call(s) via base_tools.extract_tools")
+                return parsed
+
             tool_calls: List[ToolCall] = []
 
-            # Pattern to match function name and parameters in XML format
+            # Fallback: match <function=name>...</function> style tool calls
             # Handles both <tool_call><function=name>...</function></tool_call>
             # and malformed <function=name>...</function></tool_call>
             pattern = r"<function=([^>]+)>(.*?)(?:</function>|</tool_call>)"


### PR DESCRIPTION
Qwen3 models often emit HuggingFace unified tool-use (<tool_call>{"name":..., "arguments":...}</tool_call>) instead of <function=...> tags. Update Qwen3MoeToolParser to first use the shared JSON <tool_call> extractor, then fall back to the existing <function=...> regex. Enables reliable tool execution (read/write/edit/etc.) for Qwen3 outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tool parsing with improved extraction capabilities. The system now supports multiple tool extraction formats, attempting JSON-like parsing first with automatic fallback to XML-like format parsing, ensuring compatibility with all existing tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->