### PR TITLE
mlx: accept absolute local model paths in get_model_path

### DIFF
--- a/src/mlx_omni_server/chat/mlx/model_types.py
+++ b/src/mlx_omni_server/chat/mlx/model_types.py
@@ -9,11 +9,18 @@ from mlx_lm.utils import load, load_config
 
 # Handle mlx_lm version compatibility: newer versions use hf_repo_to_path (returns Path),
 # older versions (< 0.29) use get_model_path (returns Tuple[Path, Optional[str]])
+#
+# Additionally: our deployments often pass a local filesystem path as model_id.
+# Newer huggingface_hub validators reject absolute paths as "repo ids"; treat real
+# local paths as paths and bypass hf_repo_to_path/get_model_path.
 try:
     from mlx_lm.utils import hf_repo_to_path as _get_model_path
 
     def get_model_path(model_id: str) -> Path:
         """Get model path (wrapper for newer mlx_lm versions)."""
+        p = Path(model_id)
+        if p.is_absolute() and p.exists():
+            return p
         return _get_model_path(model_id)
 
 except ImportError:
@@ -21,6 +28,9 @@ except ImportError:
 
     def get_model_path(model_id: str) -> Path:
         """Get model path (wrapper for older mlx_lm versions)."""
+        p = Path(model_id)
+        if p.is_absolute() and p.exists():
+            return p
         result = _get_model_path(model_id)
         # Old version returns Tuple[Path, Optional[str]], extract just the Path
         if isinstance(result, tuple):


### PR DESCRIPTION
Newer huggingface_hub validation rejects absolute paths as repo ids, breaking deployments that load MLX models from local directories (e.g. /Users/.../mlx/...). Update model path resolution to detect “absolute existing path” and use it directly, bypassing HF repo-id validation. Restores support for local model repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models can now be loaded from absolute local filesystem paths as an alternative to Hugging Face repository identifiers.
  * Improved compatibility for local model path handling across multiple library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->