### PR TITLE
fix: support local model paths in get_model_path

### DIFF
--- a/src/mlx_omni_server/chat/mlx/model_types.py
+++ b/src/mlx_omni_server/chat/mlx/model_types.py
@@ -14,6 +14,9 @@ try:
 
     def get_model_path(model_id: str) -> Path:
         """Get model path (wrapper for newer mlx_lm versions)."""
+        local = Path(model_id)
+        if local.exists():
+            return local  
         return _get_model_path(model_id)
 
 except ImportError:


### PR DESCRIPTION
hf_repo_to_path() calls snapshot_download() directly without checking if model_id is already a valid local path, causing HFValidationError when using absolute paths.
Fix mirrors the behavior of _download() in mlx_lm.utils: check Path.exists() first before delegating to HuggingFace Hub.

Problem: hf_repo_to_path() calls snapshot_download() directly, causing HFValidationError for local absolute paths
Root cause: Unlike _download() in mlx_lm.utils, hf_repo_to_path() has no Path.exists() guard
Fix: Added Path(model_id).exists() check before calling HF, consistent with mlx_lm behavior
Testing: Tested with local path /Users/.../model on Mac Mini M4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local model paths are now supported and prioritized when specified, allowing users to use local models directly without additional processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->