### PR TITLE
fix: serialize ToolType enum and include tool_call_id in messages

### DIFF
--- a/src/mlx_omni_server/chat/openai/openai_adapter.py
+++ b/src/mlx_omni_server/chat/openai/openai_adapter.py
@@ -152,7 +152,12 @@ class OpenAIAdapter:
                 "role": (msg.role.value if hasattr(msg.role, "value") else str(msg.role)),
                 "content": msg.content,
                 **({"name": msg.name} if msg.name else {}),
-                **({"tool_calls": msg.tool_calls} if msg.tool_calls else {}),
+                **({"tool_calls": [
+                    tc.model_dump(mode="json", exclude_none=True) 
+                    if hasattr(tc, "model_dump") else tc 
+                    for tc in msg.tool_calls
+                ]} if msg.tool_calls else {}),
+                **({"tool_call_id": msg.tool_call_id} if msg.tool_call_id else {}),
             }
             for msg in request.messages
         ]
@@ -161,12 +166,13 @@ class OpenAIAdapter:
         tools = None
         if request.tools:
             tools = [
-                tool.model_dump() if hasattr(tool, "model_dump") else dict(tool)
+                tool.model_dump(mode='json') if hasattr(tool, "model_dump") else dict(tool)
                 for tool in request.tools
             ]
 
         logger.info(f"messages: {messages}")
         logger.info(f"template_kwargs: {template_kwargs}")
+        logger.info(f"tools: {tools}")
 
         json_schema = None
         if request.response_format and request.response_format.json_schema:


### PR DESCRIPTION
## Problem

Two related bugs affecting tool calling with Mistral models:

**Bug 1: ToolType.FUNCTION enum not serialized to string**

Pydantic v2 changed the behavior of `model_dump()` — it no longer auto-serializes 
Enum values to their `.value`. As a result, `ToolType.FUNCTION` was reaching the 
Jinja chat template as a Python object instead of the string `"function"`:

Before fix:
  {'type': <ToolType.FUNCTION: 'function'>, 'function': {...}}

After fix:
  {'type': 'function', 'function': {...}}

This caused Mistral's chat template to generate a malformed prompt, 
making the model respond with plain text instead of structured tool calls.

**Bug 2: tool_call_id missing from tool role messages**

When building the messages dict for the chat template, `tool_call_id` was not 
included for messages with `role: tool`. This caused Mistral's tokenizer to throw:

  RuntimeError: Tool call IDs should be alphanumeric strings with length 9!

## Fix

- `model_dump(mode="json", exclude_none=True)` on both tools and tool_calls 
  to properly serialize enums to their string values
- Explicitly include `tool_call_id` in the messages dict for tool role messages

## Root Cause

Pydantic v2 migration — `model_dump()` behavior changed from v1 where enums 
were automatically serialized to their `.value`.

## Testing

Tested with Mistral-7B-Instruct-v0.3 (8-bit) on Mac Mini M4 via mlx-omni-server,
with parallel tool calls returning correct structured responses end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tool serialization and handling for enhanced compatibility and reliability.
  * Enhanced logging for tool operations to aid in debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->