### PR TITLE
Fix streaming thinking content leaking into content deltas

### DIFF
--- a/src/mlx_omni_server/chat/mlx/chat_generator.py
+++ b/src/mlx_omni_server/chat/mlx/chat_generator.py
@@ -476,7 +476,9 @@ class ChatGenerator:
                 chunk_index = len(generated_tokens)
 
                 # Determine which delta field to populate
-                if parse_result.thinking:
+                # Use 'is not None' to correctly handle empty string thinking
+                # (e.g. the opening <think> tag returns delta_thinking="")
+                if parse_result.thinking is not None:
                     content = StreamContent(
                         reasoning_delta=parse_result.thinking,
                         token=response.token,
@@ -484,7 +486,7 @@ class ChatGenerator:
                     )
                 else:
                     content = StreamContent(
-                        text_delta=parse_result.content or response.text,
+                        text_delta=parse_result.content if parse_result.content is not None else response.text,
                         token=response.token,
                         chunk_index=chunk_index,
                     )


### PR DESCRIPTION
## Problem

In streaming mode, thinking content (from `<think>` tags) leaks into `content` deltas instead of being sent as `reasoning` deltas. Non-streaming mode works correctly — the `reasoning` field is properly populated.

**Example:** When a model outputs `<think>The user wants...</think>Tool call here`, the streaming SSE chunks show:
```
{"delta": {"content": "The user wants..."}}   // Should NOT be in content
{"delta": {"content": "...</think>\n\n"}}      // Tag leaks through
```

## Root Cause

Two Python truthiness bugs in `chat_generator.py`'s `generate_stream()`:

### Bug 1: `if parse_result.thinking:` treats empty string as falsy

`ThinkingDecoder.stream_decode()` returns `delta_thinking=""` (empty string) when the opening `<think>` tag is processed. Empty string is falsy in Python, so it falls through to the `else` branch:

```python
# Before (buggy)
if parse_result.thinking:          # "" is falsy!
    content = StreamContent(reasoning_delta=...)
else:
    content = StreamContent(text_delta=...)  # thinking goes here
```

### Bug 2: `or` fallback leaks raw tokens

```python
# Before (buggy)
text_delta=parse_result.content or response.text
```

During the thinking phase, `parse_result.content` is `""` (empty, correctly filtered by ThinkingDecoder). But `""` is falsy, so `or` falls back to `response.text` — the raw token — leaking thinking text as content.

## Fix

```python
# After (fixed)
if parse_result.thinking is not None:    # Explicit None check
    content = StreamContent(reasoning_delta=...)
else:
    content = StreamContent(
        text_delta=parse_result.content if parse_result.content is not None else response.text,
    )
```

## Impact

- Affects all models with `<think>` tag support (Qwen3, DeepSeek, etc.)
- Non-streaming mode is unaffected (uses `parse_chat_response` which processes complete text)
- No changes to the ThinkingDecoder itself — it was working correctly all along

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed response data handling to properly preserve empty thinking and content strings as valid output instead of discarding or replacing them with fallback values.
* Improved processing logic to distinguish between empty and missing response data, ensuring empty content is accurately displayed to users rather than replaced with alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->