### PR TITLE
fix: forward enable_thinking to tokenizer so enable_thinking=false su…

### DIFF
--- a/src/mlx_omni_server/chat/mlx/chat_generator.py
+++ b/src/mlx_omni_server/chat/mlx/chat_generator.py
@@ -184,11 +184,11 @@ class ChatGenerator:
         if enable_thinking and json_schema is not None:
             template_kwargs["skip_thinking_prefill"] = True
 
-        # Map enable_thinking to enable_thinking_parse for new parameter name
+        # Map enable_thinking to enable_thinking_parse for new parameter name.
+        # Keep enable_thinking in template_kwargs so it gets forwarded to the
+        # tokenizer's apply_chat_template (e.g. Qwen3 uses it to suppress <think>).
         if "enable_thinking" in template_kwargs:
-            template_kwargs["enable_thinking_parse"] = template_kwargs.pop(
-                "enable_thinking"
-            )
+            template_kwargs["enable_thinking_parse"] = template_kwargs["enable_thinking"]
 
         prompt = self.chat_template.apply_chat_template(
             messages=messages,

--- a/src/mlx_omni_server/chat/mlx/tools/chat_template.py
+++ b/src/mlx_omni_server/chat/mlx/tools/chat_template.py
@@ -215,7 +215,9 @@ class ChatTemplate(ABC):
                 self.reason_decoder = ThinkingDecoder(init_buffer=THINK_TAG)
 
         elif enable_thinking_parse is False:
-            # No modification to prompt
+            # Ensure <think> is stripped if the tokenizer added it anyway
+            if stripped_prompt.endswith(THINK_TAG):
+                prompt = stripped_prompt[: -len(THINK_TAG)]
             self.reason_decoder = None
 
         # enable_thinking_parse is None: no modification, no decoder setup

--- a/tests/chat/mlx/test_chat_generator.py
+++ b/tests/chat/mlx/test_chat_generator.py
@@ -1,5 +1,7 @@
 """Tests for ChatGenerator."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from mlx_omni_server.chat.mlx.chat_generator import ChatGenerator
@@ -20,6 +22,28 @@ def mlx_wrapper():
 
 class TestChatGenerator:
     """Test ChatGenerator functionality."""
+
+    def test_prepare_prompt_keeps_enable_thinking_for_tokenizer(self):
+        """Test enable_thinking is mapped for parsing but still forwarded."""
+        captured_kwargs = {}
+
+        class MockChatTemplate:
+            def apply_chat_template(self, messages, tools=None, **kwargs):
+                captured_kwargs.update(kwargs)
+                return "prompt"
+
+        generator = ChatGenerator(
+            SimpleNamespace(tokenizer=object(), chat_template=MockChatTemplate())
+        )
+
+        result = generator._prepare_prompt(
+            messages=[{"role": "user", "content": "hello"}],
+            template_kwargs={"enable_thinking": False},
+        )
+
+        assert result == "prompt"
+        assert captured_kwargs["enable_thinking"] is False
+        assert captured_kwargs["enable_thinking_parse"] is False
 
     def test_initialization(self, mlx_wrapper):
         """Test basic initialization."""

--- a/tests/chat/mlx/test_chat_template.py
+++ b/tests/chat/mlx/test_chat_template.py
@@ -7,6 +7,26 @@ class TestChatTemplate:
     nonthinking_model_id = "mlx-community/gemma-3-1b-it-4bit-DWQ"
     tools_model_id = "mlx-community/Llama-3.2-1B-Instruct-4bit"
 
+    def test_thinking_disabled_strips_trailing_think_tag(self):
+        """Test defensive stripping when tokenizer still appends <think>."""
+
+        class MockTokenizer:
+            def apply_chat_template(self, **_kwargs):
+                return "prompt<think>"
+
+        chat_template = ChatTemplate(
+            tools_parser_type="qwen3", tokenizer=MockTokenizer()
+        )
+
+        prompt = chat_template.apply_chat_template(
+            messages=[{"role": "user", "content": "hello"}],
+            enable_thinking_parse=False,
+        )
+
+        assert prompt == "prompt"
+        assert chat_template.enable_thinking_parse is False
+        assert chat_template.reason_decoder is None
+
     def test_thinking_enabled(self):
         # Test explicitly enabling thinking
         model, tokenizer = load(self.thinking_model_id)


### PR DESCRIPTION
…ppresses ```<think>```

enable_thinking was consumed via .pop() into an internal enable_thinking_parse key and never forwarded to the tokenizer's apply_chat_template. Qwen3's Jinja template therefore defaulted to thinking enabled and appended <think> to every prompt regardless of the flag value.

Fix by copying instead of popping, so both keys coexist in template_kwargs. Also add a defensive strip in _process_thinking_prompt to remove a rogue <think> suffix when enable_thinking_parse is False.

Closes #115

## Bug Trace

### Step 1 — openai_adapter.py: _prepare_generation_params()
  template_kwargs = dict(extra_body)
  → template_kwargs = {"enable_thinking": False}

### Step 2 — chat_generator.py: _prepare_prompt()
  enable_thinking is renamed to an internal key via .pop(),
  removing it from template_kwargs entirely:

  template_kwargs["enable_thinking_parse"] = template_kwargs.pop("enable_thinking")
  → template_kwargs = {"enable_thinking_parse": False}
    enable_thinking is GONE

### Step 3 — chat_template.py: apply_chat_template()
  enable_thinking_parse is popped for internal use:
  self.enable_thinking_parse = kwargs.pop("enable_thinking_parse", None)  → False
  kwargs is now {} — nothing left to forward

  tokenizer is called with no enable_thinking kwarg:
  self.tokenizer.apply_chat_template(
      conversation=conversation,
      tokenize=False,
      add_generation_prompt=True,
      **kwargs,  ← empty, enable_thinking never arrives here
  )

### Step 4 — Qwen3 Jinja template (tokenizer)
  enable_thinking defaults to True (thinking model default)
  <think> is appended to the prompt unconditionally
  → prompt ends with: <|im_start|>assistant\n<think>

### Step 5 — model generation
  prompt is primed with <think>, model generates full reasoning chain
  reason_decoder=None so thinking leaks through as plain content

## Observed log:
```
  DEBUG  Encoded prompt: <|im_start|>system
         You are a helpful assistant.<|im_end|>
         <|im_start|>user
         Explain what quantum entanglement is<|im_end|>
         <|im_start|>assistant
         <think>         ← present despite enable_thinking=false

  INFO   Model Response:
         Here's a thinking process that leads to the explanation...
         1. Deconstruct the Request:   ← reasoning content in response
```

## Fix:
  chat_generator.py — copy instead of pop so enable_thinking reaches the tokenizer:
  template_kwargs["enable_thinking_parse"] = template_kwargs["enable_thinking"]
  both keys now coexist; tokenizer receives enable_thinking=False → no <think>

  chat_template.py — defensive strip in case tokenizer ignores the flag:
  elif enable_thinking_parse is False:
      if stripped_prompt.endswith(THINK_TAG):
          prompt = stripped_prompt[: -len(THINK_TAG)]
      self.reason_decoder = None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the "thinking" flag is consistently forwarded so templates receive both parsing and original indicators.
  * Strip stray trailing thinking tokens from prompts when thinking parsing is disabled, preventing unintended display of internal markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->