### PR TITLE
fix: guard against empty messages list in apply_chat_template

### DIFF
--- a/src/mlx_omni_server/chat/mlx/tools/chat_template.py
+++ b/src/mlx_omni_server/chat/mlx/tools/chat_template.py
@@ -85,7 +85,7 @@ class ChatTemplate(ABC):
         schema_tools = tools  # tools are already in dict format
 
         # Check if the last message is from assistant (for prefill)
-        should_prefill = messages[-1].get("role") == "assistant"
+        should_prefill = bool(messages) and messages[-1].get("role") == "assistant"
 
         conversation = []
         for message in messages:


### PR DESCRIPTION
## Bug

`apply_chat_template` crashes with `IndexError: list index out of range` when called with an empty `messages` list:

```python
# chat_template.py:88
should_prefill = messages[-1].get("role") == "assistant"
#                ~~~~~~~~~~^^^ IndexError when messages=[]
```

Traceback:
```
File ".../mlx_omni_server/chat/mlx/tools/chat_template.py", line 88, in apply_chat_template
    should_prefill = messages[-1].get("role") == "assistant"
IndexError: list index out of range
```

This causes `Stream generation failed: list index out of range` → `Generation failed` → `Failed to generate completion` — the server crashes on every affected request.

## Fix

One-line guard so the expression short-circuits when `messages` is empty:

```python
should_prefill = bool(messages) and messages[-1].get("role") == "assistant"
```

## Impact

Any client sending an empty `messages` list hits this crash, making all completions unavailable until the server is restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of chat template processing to prevent crashes in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->