### PR TITLE
Fix server crash when model with tool_calls have content: None

### DIFF
--- a/src/mlx_omni_server/chat/mlx/tools/chat_template.py
+++ b/src/mlx_omni_server/chat/mlx/tools/chat_template.py
@@ -64,7 +64,9 @@ class ChatTemplate(ABC):
         self.has_tools = False
         self.reason_decoder = None
         self.enable_thinking_parse: Optional[bool] = None
-        self.tools_parser: Optional[BaseToolParser] = load_tools_parser(tools_parser_type)
+        self.tools_parser: Optional[BaseToolParser] = load_tools_parser(
+            tools_parser_type
+        )
 
         # Initialize tool call markers with default values
         self.start_tool_calls = self.tools_parser.start_tool_calls
@@ -95,7 +97,9 @@ class ChatTemplate(ABC):
                 msg_dict["content"] = ""
             if isinstance(msg_dict.get("content"), list):
                 msg_dict["content"] = "\n\n".join(
-                    item["text"] for item in msg_dict["content"] if item.get("type") == "text"
+                    item["text"]
+                    for item in msg_dict["content"]
+                    if item.get("type") == "text"
                 )
             # Convert tool_calls arguments from JSON string to dict for Jinja template
             # The Qwen3 chat template expects arguments as a dict, not a JSON string
@@ -250,16 +254,22 @@ class ChatTemplate(ABC):
             thinking = result.get("thinking")
 
         if self.has_tools:
-            logger.debug(f"parse_chat_response: has_tools=True, parser type={type(self.tools_parser).__name__}")
+            logger.debug(
+                f"parse_chat_response: has_tools=True, parser type={type(self.tools_parser).__name__}"
+            )
             tool_calls = self.tools_parser.parse_tools(content)
 
             # If tool calls were found, clear content to avoid duplication
             if tool_calls:
-                logger.debug(f"parse_chat_response: found {len(tool_calls)} tool call(s)")
+                logger.debug(
+                    f"parse_chat_response: found {len(tool_calls)} tool call(s)"
+                )
                 content = ""
             else:
                 logger.debug("parse_chat_response: no tool calls found by parser")
         else:
             logger.debug("parse_chat_response: has_tools=False, skipping tool parsing")
 
-        return ChatTemplateResult(content=content, thinking=thinking, tool_calls=tool_calls)
+        return ChatTemplateResult(
+            content=content, thinking=thinking, tool_calls=tool_calls
+        )

--- a/src/mlx_omni_server/chat/mlx/tools/chat_template.py
+++ b/src/mlx_omni_server/chat/mlx/tools/chat_template.py
@@ -91,6 +91,8 @@ class ChatTemplate(ABC):
         for message in messages:
             # messages are already in dict format
             msg_dict = message.copy()  # Make a copy to avoid modifying original
+            if msg_dict.get("content") is None:
+                msg_dict["content"] = ""
             if isinstance(msg_dict.get("content"), list):
                 msg_dict["content"] = "\n\n".join(
                     item["text"] for item in msg_dict["content"] if item.get("type") == "text"

--- a/tests/chat/mlx/test_chat_template.py
+++ b/tests/chat/mlx/test_chat_template.py
@@ -298,6 +298,38 @@ class TestChatTemplate:
 
         print("✓ OpenAI adapter tool call conversion test passed")
 
+    def test_tool_calls_none_content_coerced(self):
+        """Test that assistant messages with tool_calls and content=None don't crash."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "NYC"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_abc", "content": "Sunny, 25°C"},
+            {"role": "user", "content": "Thanks"},
+        ]
+
+        class CapturingMockTokenizer:
+            def apply_chat_template(self, conversation, **_kwargs):
+                for msg in conversation:
+                    if msg.get("role") == "assistant" and "tool_calls" in msg:
+                        assert msg["content"] == "", f"Expected '', got {msg['content']!r}"
+                return "ok"
+
+        chat_template = ChatTemplate(
+            tools_parser_type="qwen3", tokenizer=CapturingMockTokenizer()
+        )
+        result = chat_template.apply_chat_template(messages=messages)
+        assert result == "ok"
+
     def test_openai_adapter_none_input(self):
         """Test that _convert_tool_calls handles None input correctly"""
         from mlx_omni_server.chat.openai.openai_adapter import _convert_tool_calls

--- a/tests/chat/mlx/test_chat_template.py
+++ b/tests/chat/mlx/test_chat_template.py
@@ -1,4 +1,5 @@
 from mlx_lm import load
+
 from mlx_omni_server.chat.mlx.tools.chat_template import ChatTemplate
 
 
@@ -212,7 +213,9 @@ class TestChatTemplate:
         messages = [{"role": "user", "content": "test"}]
 
         # This should not raise an error even with extra kwargs
-        prompt = chat_template.apply_chat_template(messages=messages, custom_param="test_value")
+        prompt = chat_template.apply_chat_template(
+            messages=messages, custom_param="test_value"
+        )
         assert isinstance(prompt, str)
 
     def test_tool_calls_json_conversion(self):
@@ -309,7 +312,10 @@ class TestChatTemplate:
                     {
                         "id": "call_abc",
                         "type": "function",
-                        "function": {"name": "get_weather", "arguments": '{"location": "NYC"}'},
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "NYC"}',
+                        },
                     }
                 ],
             },
@@ -321,7 +327,9 @@ class TestChatTemplate:
             def apply_chat_template(self, conversation, **_kwargs):
                 for msg in conversation:
                     if msg.get("role") == "assistant" and "tool_calls" in msg:
-                        assert msg["content"] == "", f"Expected '', got {msg['content']!r}"
+                        assert (
+                            msg["content"] == ""
+                        ), f"Expected '', got {msg['content']!r}"
                 return "ok"
 
         chat_template = ChatTemplate(


### PR DESCRIPTION
## Fix: coerce None content to empty string in apply_chat_template to prevent server crash from tool_call responses with content: None

## Bug

Assistant messages that contain only `tool_calls` have `content: None`, which is valid per the OpenAI spec, cause the server to crash due to `apply_chat_template` passing `None` straight to the Jinja template.

## Steps to Reproduce

Clone the repo at `main` (pre-fix) and run:
```python
from mlx_omni_server.chat.mlx.tools.chat_template import ChatTemplate

class MockTokenizer:
    def apply_chat_template(self, conversation, **kwargs):
        out = ""
        for msg in conversation:
            out += msg["role"] + "\n" + msg["content"]
        return out

ct = ChatTemplate(tools_parser_type="qwen3", tokenizer=MockTokenizer())

ct.apply_chat_template(messages=[
    {"role": "user", "content": "What is the weather in NYC?"},
    {
        "role": "assistant",
        "content": None,          # OpenAI returns None here — valid per spec
        "tool_calls": [{"id": "call_1", "type": "function",
                        "function": {"name": "get_weather",
                                     "arguments": '{"location":"NYC"}'}}],
    },
    {"role": "tool", "tool_call_id": "call_1", "content": "72°F and sunny"},
    {"role": "user", "content": "Thanks"},
])
```

You will get the following traceback:
```bash
File "chat_template.py", line 141, in apply_chat_template
  prompt = self.tokenizer.apply_chat_template(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can only concatenate str (not "NoneType") to str
```

Any multi-turn conversation that includes a prior tool-call round trips into this.

# Fix

Coerce `content=None` to `""` before building the conversation list. This addition is consistent with the list-content normalisation directly below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3-TTS model integration with voice design and reference audio capabilities.

* **Tests**
  * Added test coverage for tool calling with null content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->