### PR TITLE
Improve MLX model cache memory management

### DIFF
--- a/src/mlx_omni_server/chat/mlx/chat_generator.py
+++ b/src/mlx_omni_server/chat/mlx/chat_generator.py
@@ -1,5 +1,6 @@
 """Chat Generator - Core abstraction layer over mlx-lm for chat completions."""
 
+import json
 import time
 from typing import Any, Callable, Dict, Generator, List, Optional, Union
 
@@ -156,6 +157,49 @@ class ChatGenerator:
         """Check if this wrapper has a draft model for speculative decoding."""
         return self.model.has_draft_model()
 
+    @staticmethod
+    def _split_text_before_json(text: str) -> tuple[str | None, str | None]:
+        stripped = text.strip()
+        for index, char in enumerate(stripped):
+            if char not in "[{":
+                continue
+            try:
+                json.loads(stripped[index:])
+            except json.JSONDecodeError:
+                continue
+            prefix = stripped[:index].strip()
+            return (prefix or None, stripped[index:].strip())
+        return None, None
+
+    @classmethod
+    def _merge_streamed_content(
+        cls,
+        chat_result,
+        streamed_text: str,
+        streamed_reasoning: str,
+        json_schema: Optional[Any] = None,
+    ) -> tuple[str, str | None]:
+        content = chat_result.content
+        reasoning = chat_result.thinking
+
+        if json_schema is not None:
+            fallback_reasoning, fallback_content = cls._split_text_before_json(content)
+            if fallback_content is None and streamed_reasoning and not streamed_text:
+                fallback_reasoning, fallback_content = cls._split_text_before_json(
+                    streamed_reasoning
+                )
+            if fallback_content is not None:
+                content = fallback_content
+                if not reasoning:
+                    reasoning = fallback_reasoning
+
+        if streamed_reasoning and not reasoning:
+            reasoning = streamed_reasoning.strip() or None
+            if streamed_text and not chat_result.tool_calls:
+                content = streamed_text.strip()
+
+        return content, reasoning
+
     def _prepare_prompt(
         self,
         messages: List[Dict[str, Any]],
@@ -188,7 +232,9 @@ class ChatGenerator:
         # Keep enable_thinking in template_kwargs so it gets forwarded to the
         # tokenizer's apply_chat_template (e.g. Qwen3 uses it to suppress <think>).
         if "enable_thinking" in template_kwargs:
-            template_kwargs["enable_thinking_parse"] = template_kwargs["enable_thinking"]
+            template_kwargs["enable_thinking_parse"] = template_kwargs[
+                "enable_thinking"
+            ]
 
         prompt = self.chat_template.apply_chat_template(
             messages=messages,
@@ -314,13 +360,13 @@ class ChatGenerator:
         """
         try:
             # Check if we need to use mlx_vlm for VLM-only models
-            if getattr(self.model, 'is_vlm_model', False):
+            if getattr(self.model, "is_vlm_model", False):
                 from mlx_vlm import generate as vlm_generate
-                
+
                 # Extract images and audio from messages for VLM
                 images_list = []
                 audios_list = []
-                
+
                 for msg in messages:
                     if isinstance(msg.get("content"), list):
                         for item in msg["content"]:
@@ -348,7 +394,7 @@ class ChatGenerator:
                                         url = str(audio_url)
                                     if url:
                                         audios_list.append(url)
-                
+
                 # For VLM models, use mlx_vlm's generate directly
                 vlm_template_kwargs = dict(template_kwargs or {})
                 vlm_template_kwargs.setdefault("num_images", len(images_list))
@@ -362,7 +408,7 @@ class ChatGenerator:
                     max_tokens=max_tokens,
                     **kwargs,
                 )
-                
+
                 # Pass images and audio to VLM generate
                 result = vlm_generate(
                     model=self.model.model.model,  # Unwrap VLM model
@@ -372,24 +418,26 @@ class ChatGenerator:
                     audio=audios_list if audios_list else None,
                     **mlx_kwargs,
                 )
-                
+
                 # Extract text from result
-                complete_raw_text = result.text if hasattr(result, 'text') else str(result)
-                
+                complete_raw_text = (
+                    result.text if hasattr(result, "text") else str(result)
+                )
+
                 # Create stats similar to stream results
                 stats = GenerationStats(
-                    prompt_tokens=getattr(result, 'prompt_tokens', 0),
-                    completion_tokens=getattr(result, 'generation_tokens', 0),
-                    prompt_tps=getattr(result, 'prompt_tps', 0.0),
-                    generation_tps=getattr(result, 'generation_tps', 0.0),
-                    peak_memory=getattr(result, 'peak_memory', 0.0),
+                    prompt_tokens=getattr(result, "prompt_tokens", 0),
+                    completion_tokens=getattr(result, "generation_tokens", 0),
+                    prompt_tps=getattr(result, "prompt_tps", 0.0),
+                    generation_tps=getattr(result, "generation_tps", 0.0),
+                    peak_memory=getattr(result, "peak_memory", 0.0),
                     cache_hit_tokens=0,
                     time_to_first_token=0.0,
                 )
-                
+
                 # Parse the response
                 chat_result = self.chat_template.parse_chat_response(complete_raw_text)
-                
+
                 # Create CompletionContent
                 content = CompletionContent(
                     text=chat_result.content,
@@ -398,7 +446,7 @@ class ChatGenerator:
                     text_tokens=[],  # Empty list for VLM (not collected from streaming)
                     reasoning_tokens=None,
                 )
-                
+
                 # Return result
                 return GenerationResult(
                     content=content,
@@ -407,10 +455,12 @@ class ChatGenerator:
                     logprobs=None,
                     from_draft=False,
                 )
-            
+
             # Standard generation for non-VLM models
             # Generate complete response by collecting stream.
             complete_raw_text = ""
+            streamed_text = ""
+            streamed_reasoning = ""
             final_stream_result = None
             all_text_tokens = []
             all_reasoning_tokens = []
@@ -428,10 +478,12 @@ class ChatGenerator:
                 # Collect deltas to reconstruct complete content
                 if stream_result.content.text_delta:
                     complete_raw_text += stream_result.content.text_delta
+                    streamed_text += stream_result.content.text_delta
                     all_text_tokens.append(stream_result.content.token)
                 elif stream_result.content.reasoning_delta:
                     # Reasoning tokens should also be included in complete_raw_text
                     complete_raw_text += stream_result.content.reasoning_delta
+                    streamed_reasoning += stream_result.content.reasoning_delta
                     all_reasoning_tokens.append(stream_result.content.token)
 
                 final_stream_result = stream_result
@@ -441,6 +493,12 @@ class ChatGenerator:
 
             logger.info(f"Model Response:\n{complete_raw_text}")
             chat_result = self.chat_template.parse_chat_response(complete_raw_text)
+            content_text, reasoning_text = self._merge_streamed_content(
+                chat_result,
+                streamed_text=streamed_text,
+                streamed_reasoning=streamed_reasoning,
+                json_schema=kwargs.get("json_schema"),
+            )
 
             # Determine appropriate finish_reason
             finish_reason = final_stream_result.finish_reason
@@ -449,8 +507,8 @@ class ChatGenerator:
 
             # Create CompletionContent with complete data
             content = CompletionContent(
-                text=chat_result.content,
-                reasoning=chat_result.thinking,
+                text=content_text,
+                reasoning=reasoning_text,
                 tool_calls=chat_result.tool_calls,
                 text_tokens=all_text_tokens,
                 reasoning_tokens=all_reasoning_tokens if all_reasoning_tokens else None,
@@ -508,7 +566,7 @@ class ChatGenerator:
 
         try:
             # Check if we need to use mlx_vlm for VLM-only models
-            if getattr(self.model, 'is_vlm_model', False):
+            if getattr(self.model, "is_vlm_model", False):
                 raise NotImplementedError(
                     "Streaming is not yet supported for VLM-only models (like Gemma 4). "
                     "Please use the non-streaming generate() method instead."

--- a/src/mlx_omni_server/chat/mlx/wrapper_cache.py
+++ b/src/mlx_omni_server/chat/mlx/wrapper_cache.py
@@ -5,14 +5,70 @@ to avoid expensive model reloading when the same model configuration is used
 across different API endpoints.
 """
 
+import gc
+import os
 import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from ...utils.logger import logger
 from .chat_generator import ChatGenerator
+
+DEFAULT_MODEL_CACHE_SIZE = 1
+DEFAULT_MODEL_CACHE_TTL_SECONDS = 300
+MODEL_CACHE_SIZE_ENV = "MLX_OMNI_MODEL_CACHE_SIZE"
+MODEL_CACHE_TTL_ENV = "MLX_OMNI_MODEL_CACHE_TTL"
+
+
+def parse_non_negative_int(value: str | int, name: str) -> int:
+    """Parse a non-negative integer config value."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a non-negative integer") from exc
+
+    if parsed < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return parsed
+
+
+def get_model_cache_config_from_env(
+    environ: dict[str, str] | None = None
+) -> tuple[int, int]:
+    """Read model cache configuration from environment variables."""
+    environ = os.environ if environ is None else environ
+    max_size = parse_non_negative_int(
+        environ.get(MODEL_CACHE_SIZE_ENV, DEFAULT_MODEL_CACHE_SIZE),
+        MODEL_CACHE_SIZE_ENV,
+    )
+    ttl_seconds = parse_non_negative_int(
+        environ.get(MODEL_CACHE_TTL_ENV, DEFAULT_MODEL_CACHE_TTL_SECONDS),
+        MODEL_CACHE_TTL_ENV,
+    )
+    return max_size, ttl_seconds
+
+
+def clear_mlx_memory() -> None:
+    """Run best-effort Python and MLX memory cleanup."""
+    gc.collect()
+
+    try:
+        import mlx.metal as metal
+    except ModuleNotFoundError:
+        logger.debug("mlx.metal is not available; skipped MLX cache cleanup")
+        return
+    except Exception as e:
+        logger.warning(f"Failed to import mlx.metal for cache cleanup: {e}")
+        return
+
+    try:
+        clear_cache = getattr(metal, "clear_cache", None)
+        if clear_cache is not None:
+            clear_cache()
+    except Exception as e:
+        logger.warning(f"Failed to clear MLX metal cache: {e}")
 
 
 @dataclass(frozen=True)
@@ -40,39 +96,61 @@ class MLXWrapperCache:
     """
 
     def __init__(
-        self, max_size: int = 3, ttl_seconds: int = 300, cleanup_interval: int = 5
+        self,
+        max_size: int = DEFAULT_MODEL_CACHE_SIZE,
+        ttl_seconds: int = DEFAULT_MODEL_CACHE_TTL_SECONDS,
+        cleanup_interval: int = 5,
     ):
         """Initialize cache with LRU eviction and TTL support.
 
         Args:
-            max_size: Maximum number of models to cache (default: 3)
+            max_size: Maximum number of models to cache.
             ttl_seconds: Time to live in seconds, after which unused models
-                        are evicted from cache (default: 300 seconds = 5 minutes)
-            cleanup_interval: Interval in seconds for background cleanup (default: 5 seconds)
+                        are evicted from cache.
+            cleanup_interval: Interval in seconds for background cleanup.
         """
         self._cache: OrderedDict[WrapperCacheKey, ChatGenerator] = OrderedDict()
         self._access_times: Dict[WrapperCacheKey, float] = {}
         self._lock = threading.Lock()
-        self._max_size = max_size
-        self._ttl_seconds = ttl_seconds
+        self._load_lock = threading.Lock()
+        self._max_size = parse_non_negative_int(max_size, "max_size")
+        self._ttl_seconds = parse_non_negative_int(ttl_seconds, "ttl_seconds")
         self._cleanup_interval = cleanup_interval
         self._stop_event = threading.Event()
         self._cleanup_thread = None
 
-        # Start background cleanup thread if TTL is enabled
         if self._ttl_seconds > 0:
             self._cleanup_thread = threading.Thread(
                 target=self._periodic_cleanup, daemon=True
             )
             self._cleanup_thread.start()
 
-    def _evict_expired_items(self) -> None:
-        """Evict items that have exceeded their TTL.
+    def _release_evicted_items(
+        self, evicted_items: list[tuple[WrapperCacheKey, ChatGenerator]]
+    ) -> None:
+        """Release cache-owned references after wrappers leave the cache."""
+        if not evicted_items:
+            return
+        evicted_items.clear()
+        clear_mlx_memory()
 
-        This method should be called while holding the lock.
-        """
+    def _pop_lru_locked(self) -> tuple[WrapperCacheKey, ChatGenerator] | None:
+        if not self._cache:
+            return None
+        lru_key = min(self._access_times.keys(), key=lambda k: self._access_times[k])
+        wrapper = self._cache.pop(lru_key, None)
+        self._access_times.pop(lru_key, None)
+        logger.info(f"Evicted LRU model from cache: {lru_key}")
+        if wrapper is None:
+            return None
+        return lru_key, wrapper
+
+    def _evict_expired_items_locked(
+        self,
+    ) -> list[tuple[WrapperCacheKey, ChatGenerator]]:
+        """Evict items that have exceeded their TTL while holding the lock."""
         if self._ttl_seconds <= 0:
-            return  # TTL disabled
+            return []
 
         current_time = time.time()
         expired_keys = []
@@ -81,33 +159,36 @@ class MLXWrapperCache:
             if current_time - access_time > self._ttl_seconds:
                 expired_keys.append(key)
 
+        evicted_items = []
         for key in expired_keys:
-            self._cache.pop(key, None)
+            wrapper = self._cache.pop(key, None)
             self._access_times.pop(key, None)
+            if wrapper is not None:
+                evicted_items.append((key, wrapper))
             logger.info(
                 f"Evicted expired model from cache (TTL={self._ttl_seconds}s): {key}"
             )
 
-    def _evict_lru_if_needed(self) -> None:
-        """Evict least recently used item if cache is at capacity.
+        return evicted_items
 
-        This method should be called while holding the lock.
-        """
-        if len(self._cache) >= self._max_size and self._max_size > 0:
-            # Find the least recently used key
-            lru_key = min(
-                self._access_times.keys(), key=lambda k: self._access_times[k]
-            )
+    def _evict_lru_for_new_item_locked(
+        self,
+    ) -> list[tuple[WrapperCacheKey, ChatGenerator]]:
+        """Evict one LRU item if needed before adding a new cache entry."""
+        if self._max_size <= 0 or len(self._cache) < self._max_size:
+            return []
+        item = self._pop_lru_locked()
+        return [item] if item is not None else []
 
-            # Remove from cache and access times
-            self._cache.pop(lru_key, None)
-            self._access_times.pop(lru_key, None)
-
-            logger.info(f"Evicted LRU model from cache: {lru_key}")
-
-            # Optional: Clean up the evicted wrapper's resources
-            # This could include clearing VRAM, etc., but ChatGenerator
-            # doesn't currently expose cleanup methods
+    def _shrink_to_max_size_locked(self) -> list[tuple[WrapperCacheKey, ChatGenerator]]:
+        """Evict cached entries until cache_size <= max_size."""
+        evicted_items = []
+        while len(self._cache) > self._max_size:
+            item = self._pop_lru_locked()
+            if item is None:
+                break
+            evicted_items.append(item)
+        return evicted_items
 
     def _update_access_time(self, key: WrapperCacheKey) -> None:
         """Update access time for LRU tracking.
@@ -124,7 +205,8 @@ class MLXWrapperCache:
         while not self._stop_event.wait(self._cleanup_interval):
             try:
                 with self._lock:
-                    self._evict_expired_items()
+                    evicted_items = self._evict_expired_items_locked()
+                self._release_evicted_items(evicted_items)
             except Exception as e:
                 logger.error(f"Error in periodic cleanup: {e}")
 
@@ -135,6 +217,16 @@ class MLXWrapperCache:
             self._cleanup_thread.join(timeout=1.0)
             self._cleanup_thread = None
             logger.info("Background cleanup thread stopped")
+
+    def _get_cached_wrapper(self, key: WrapperCacheKey) -> ChatGenerator | None:
+        with self._lock:
+            evicted_items = self._evict_expired_items_locked()
+            wrapper = self._cache.get(key)
+            if wrapper is not None:
+                self._update_access_time(key)
+                logger.debug(f"Cache hit for ChatGenerator: {key}")
+        self._release_evicted_items(evicted_items)
+        return wrapper
 
     def get_wrapper(
         self,
@@ -162,33 +254,29 @@ class MLXWrapperCache:
             draft_model_id=draft_model_id,
         )
 
-        # Double-checked locking pattern for performance
-        if key in self._cache:
+        wrapper = self._get_cached_wrapper(key)
+        if wrapper is not None:
+            return wrapper
+
+        with self._load_lock:
+            wrapper = self._get_cached_wrapper(key)
+            if wrapper is not None:
+                return wrapper
+
             with self._lock:
-                # Evict expired items before checking cache
-                self._evict_expired_items()
-
-                # Check if key still exists after expiry cleanup
+                evicted_items = self._evict_expired_items_locked()
                 if key in self._cache:
-                    # Update access time for LRU and TTL
                     self._update_access_time(key)
-                    logger.debug(f"Cache hit for ChatGenerator: {key}")
-                    return self._cache[key]
+                    wrapper = self._cache[key]
+                else:
+                    evicted_items.extend(self._evict_lru_for_new_item_locked())
+                    wrapper = None
+            self._release_evicted_items(evicted_items)
 
-        with self._lock:
-            # Evict expired items first
-            self._evict_expired_items()
+            if wrapper is not None:
+                logger.debug(f"Cache hit (after load lock) for ChatGenerator: {key}")
+                return wrapper
 
-            # Check again inside lock in case another thread created it
-            if key in self._cache:
-                self._update_access_time(key)
-                logger.debug(f"Cache hit (after lock) for ChatGenerator: {key}")
-                return self._cache[key]
-
-            # Cache miss - evict LRU if needed before creating new wrapper
-            self._evict_lru_if_needed()
-
-            # Create new wrapper
             logger.info(f"Creating new ChatGenerator for: {key}")
             try:
                 wrapper = ChatGenerator.create(
@@ -196,9 +284,14 @@ class MLXWrapperCache:
                     adapter_path=adapter_path,
                     draft_model_id=draft_model_id,
                 )
+            except Exception as e:
+                logger.error(f"Failed to create ChatGenerator for {key}: {e}")
+                raise
 
-                # Only cache if max_size > 0
+            with self._lock:
+                evicted_items = []
                 if self._max_size > 0:
+                    evicted_items = self._evict_lru_for_new_item_locked()
                     self._cache[key] = wrapper
                     self._update_access_time(key)
                     logger.info(
@@ -208,11 +301,8 @@ class MLXWrapperCache:
                     logger.info(
                         f"Created ChatGenerator but not cached (max_size=0): {key}"
                     )
-
-                return wrapper
-            except Exception as e:
-                logger.error(f"Failed to create ChatGenerator for {key}: {e}")
-                raise
+            self._release_evicted_items(evicted_items)
+            return wrapper
 
     def cleanup_expired_items(self) -> int:
         """Manually trigger cleanup of expired items.
@@ -224,45 +314,47 @@ class MLXWrapperCache:
             Number of items that were evicted
         """
         with self._lock:
-            initial_size = len(self._cache)
-            self._evict_expired_items()
-            evicted_count = initial_size - len(self._cache)
+            evicted_items = self._evict_expired_items_locked()
+        evicted_count = len(evicted_items)
+        self._release_evicted_items(evicted_items)
 
-            if evicted_count > 0:
-                logger.info(f"Manual cleanup evicted {evicted_count} expired items")
+        if evicted_count > 0:
+            logger.info(f"Manual cleanup evicted {evicted_count} expired items")
 
-            return evicted_count
+        return evicted_count
 
-    def clear_cache(self) -> None:
+    def clear_cache(self) -> int:
         """Clear all cached wrapper instances.
 
         This can be useful for memory management or testing purposes.
-        """
-        # Stop the cleanup thread first
-        self._stop_cleanup_thread()
 
+        Returns:
+            Number of cached wrappers that were cleared.
+        """
         with self._lock:
-            cache_size = len(self._cache)
+            items = list(self._cache.items())
             self._cache.clear()
             self._access_times.clear()
-            logger.info(f"Cleared ChatGenerator cache ({cache_size} entries)")
 
-    def get_cache_info(self) -> Dict[str, any]:
+        cache_size = len(items)
+        self._release_evicted_items(items)
+        logger.info(f"Cleared ChatGenerator cache ({cache_size} entries)")
+        return cache_size
+
+    def get_cache_info(self) -> Dict[str, Any]:
         """Get cache statistics.
 
         Returns:
             Dictionary with cache statistics including LRU and TTL information
         """
         with self._lock:
-            # Clean up expired items first to get accurate stats
-            self._evict_expired_items()
+            evicted_items = self._evict_expired_items_locked()
 
             current_time = time.time()
             sorted_keys = sorted(
                 self._access_times.items(), key=lambda x: x[1], reverse=True
             )
 
-            # Calculate TTL remaining for each item
             ttl_info = []
             if self._ttl_seconds > 0:
                 for key, access_time in sorted_keys:
@@ -275,14 +367,17 @@ class MLXWrapperCache:
                         }
                     )
 
-            return {
+            cache_info = {
                 "cache_size": len(self._cache),
                 "max_size": self._max_size,
                 "ttl_seconds": self._ttl_seconds,
                 "cached_keys": [str(key) for key in self._cache.keys()],
-                "lru_order": [str(key) for key, _ in sorted_keys],  # Most recent first
+                "lru_order": [str(key) for key, _ in sorted_keys],
                 "ttl_info": ttl_info,
             }
+
+        self._release_evicted_items(evicted_items)
+        return cache_info
 
     def set_max_size(self, max_size: int) -> None:
         """Update the maximum cache size.
@@ -294,22 +389,45 @@ class MLXWrapperCache:
             If the new size is smaller than current cache size,
             LRU items will be evicted immediately.
         """
+        max_size = parse_non_negative_int(max_size, "max_size")
         with self._lock:
             self._max_size = max_size
+            evicted_items = self._shrink_to_max_size_locked()
+            current_size = len(self._cache)
+        self._release_evicted_items(evicted_items)
+        logger.info(
+            f"Updated cache max_size to {max_size}, current size: {current_size}"
+        )
 
-            # Evict items if current cache exceeds new limit
-            while len(self._cache) > self._max_size:
-                self._evict_lru_if_needed()
+    def set_ttl_seconds(self, ttl_seconds: int) -> None:
+        """Update cache TTL seconds."""
+        ttl_seconds = parse_non_negative_int(ttl_seconds, "ttl_seconds")
+        stop_cleanup_thread = False
+        with self._lock:
+            self._ttl_seconds = ttl_seconds
 
-            logger.info(
-                f"Updated cache max_size to {max_size}, current size: {len(self._cache)}"
-            )
+            if self._ttl_seconds > 0 and self._cleanup_thread is None:
+                self._stop_event.clear()
+                self._cleanup_thread = threading.Thread(
+                    target=self._periodic_cleanup, daemon=True
+                )
+                self._cleanup_thread.start()
+            elif self._ttl_seconds <= 0:
+                stop_cleanup_thread = True
+
+            logger.info(f"Updated cache ttl_seconds to {ttl_seconds}")
+
+        if stop_cleanup_thread:
+            self._stop_cleanup_thread()
+
+    def configure(self, max_size: int, ttl_seconds: int) -> None:
+        """Update cache max size and TTL."""
+        self.set_max_size(max_size)
+        self.set_ttl_seconds(ttl_seconds)
 
     def __del__(self) -> None:
         """Destructor to ensure cleanup thread is stopped."""
         self._stop_cleanup_thread()
 
 
-# Global cache instance - shared across all API endpoints
-# Default to 3 models with 5-minute TTL as suggested by user requirements
-wrapper_cache = MLXWrapperCache(max_size=3, ttl_seconds=300)
+wrapper_cache = MLXWrapperCache(*get_model_cache_config_from_env())

--- a/src/mlx_omni_server/chat/openai/cache_router.py
+++ b/src/mlx_omni_server/chat/openai/cache_router.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from mlx_omni_server.chat.mlx.wrapper_cache import wrapper_cache
+
+router = APIRouter(tags=["cache"])
+
+
+@router.get("/v1/cache")
+async def get_cache_info():
+    """Return current ChatGenerator cache information."""
+    return JSONResponse(content=wrapper_cache.get_cache_info())
+
+
+@router.post("/v1/cache/clear")
+async def clear_cache():
+    """Clear cached ChatGenerator instances."""
+    cleared_count = wrapper_cache.clear_cache()
+    return JSONResponse(
+        content={
+            "cleared_count": cleared_count,
+            "cache_info": wrapper_cache.get_cache_info(),
+        }
+    )

--- a/src/mlx_omni_server/main.py
+++ b/src/mlx_omni_server/main.py
@@ -4,6 +4,12 @@ import os
 import uvicorn
 from fastapi import FastAPI
 
+from .chat.mlx.wrapper_cache import (
+    MODEL_CACHE_SIZE_ENV,
+    MODEL_CACHE_TTL_ENV,
+    get_model_cache_config_from_env,
+    wrapper_cache,
+)
 from .middleware.logging import RequestResponseLoggingMiddleware
 from .routers import api_router
 from .utils.logger import logger, set_logger_level
@@ -48,6 +54,20 @@ def build_parser():
         default="info",
         choices=["debug", "info", "warning", "error", "critical"],
         help="Set the logging level, defaults to info",
+    )
+
+    default_cache_size, default_cache_ttl = get_model_cache_config_from_env()
+    parser.add_argument(
+        "--model-cache-size",
+        type=int,
+        default=default_cache_size,
+        help=f"Maximum ChatGenerator wrappers to cache, defaults to {default_cache_size}",
+    )
+    parser.add_argument(
+        "--model-cache-ttl",
+        type=int,
+        default=default_cache_ttl,
+        help=f"Seconds before unused ChatGenerator wrappers expire, defaults to {default_cache_ttl}",
     )
 
     parser.add_argument(
@@ -97,9 +117,20 @@ def start():
     os.environ["MLX_OMNI_LOG_LEVEL"] = args.log_level
     # Set CORS through environment variable
     os.environ["MLX_OMNI_CORS"] = args.cors_allow_origins
+    os.environ[MODEL_CACHE_SIZE_ENV] = str(args.model_cache_size)
+    os.environ[MODEL_CACHE_TTL_ENV] = str(args.model_cache_ttl)
 
     set_logger_level(logger, args.log_level)
     configure_cors_middleware(args.cors_allow_origins)
+    wrapper_cache.configure(args.model_cache_size, args.model_cache_ttl)
+
+    if args.workers > 1:
+        logger.warning(
+            "Running with %s workers. Each worker process maintains its own "
+            "independent model cache, so model memory usage may scale up to "
+            "the worker count.",
+            args.workers,
+        )
 
     # Start server with uvicorn
     uvicorn.run(

--- a/src/mlx_omni_server/routers.py
+++ b/src/mlx_omni_server/routers.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from .chat.anthropic import router as anthropic_router
+from .chat.openai import cache_router
 from .chat.openai import router as chat_router
 from .chat.openai.models import models
 from .embeddings import router as embeddings_router
@@ -13,6 +14,7 @@ api_router.include_router(stt_router.router)
 api_router.include_router(tts_router.router)
 api_router.include_router(models.router)
 api_router.include_router(images.router)
+api_router.include_router(cache_router.router)
 api_router.include_router(chat_router.router)
 api_router.include_router(embeddings_router.router)
 api_router.include_router(anthropic_router.router, prefix="/anthropic")

--- a/tests/chat/mlx/test_chat_generator.py
+++ b/tests/chat/mlx/test_chat_generator.py
@@ -6,9 +6,11 @@ import pytest
 
 from mlx_omni_server.chat.mlx.chat_generator import ChatGenerator
 from mlx_omni_server.chat.mlx.core_types import (
+    ChatTemplateResult,
     CompletionContent,
     GenerationResult,
     StreamContent,
+    ToolCall,
 )
 from mlx_omni_server.utils.logger import logger
 
@@ -22,6 +24,38 @@ def mlx_wrapper():
 
 class TestChatGenerator:
     """Test ChatGenerator functionality."""
+
+    def test_merge_streamed_reasoning_keeps_tool_content_empty(self):
+        chat_result = ChatTemplateResult(
+            content="",
+            thinking=None,
+            tool_calls=[ToolCall(id="call_1", name="get_weather", arguments={})],
+        )
+
+        content, reasoning = ChatGenerator._merge_streamed_content(
+            chat_result,
+            streamed_text='<tool_call>{"name":"get_weather"}</tool_call>',
+            streamed_reasoning="Need the weather tool.",
+        )
+
+        assert content == ""
+        assert reasoning == "Need the weather tool."
+
+    def test_merge_schema_output_splits_reasoning_before_json(self):
+        chat_result = ChatTemplateResult(
+            content='Think it through.\n{"final_answer":"6","steps":[]}',
+            thinking=None,
+        )
+
+        content, reasoning = ChatGenerator._merge_streamed_content(
+            chat_result,
+            streamed_text="",
+            streamed_reasoning='Think it through.\n{"final_answer":"6","steps":[]}',
+            json_schema={"type": "object"},
+        )
+
+        assert content == '{"final_answer":"6","steps":[]}'
+        assert reasoning == "Think it through."
 
     def test_prepare_prompt_keeps_enable_thinking_for_tokenizer(self):
         """Test enable_thinking is mapped for parsing but still forwarded."""
@@ -410,7 +444,9 @@ class TestChatGenerator:
             {
                 "apply_chat_template": lambda self, messages, tools=None, **kwargs: messages[
                     0
-                ]["content"],
+                ][
+                    "content"
+                ],
                 "stream_parse_chat_result": lambda self, text: type(
                     "ParseResult", (), {"thinking": None, "content": text}
                 )(),
@@ -442,7 +478,8 @@ class TestChatGenerator:
             yield done
 
         monkeypatch.setattr(
-            "mlx_omni_server.chat.mlx.chat_generator.stream_generate", fake_stream_generate
+            "mlx_omni_server.chat.mlx.chat_generator.stream_generate",
+            fake_stream_generate,
         )
 
         assert wrapper.prompt_cache_pool.get_pool_info()["pool_size"] == 0
@@ -474,7 +511,9 @@ class TestChatGenerator:
 
             def parse_chat_response(self, text):
                 return type(
-                    "ChatResult", (), {"content": text, "thinking": None, "tool_calls": None}
+                    "ChatResult",
+                    (),
+                    {"content": text, "thinking": None, "tool_calls": None},
                 )()
 
         wrapper = ChatGenerator.__new__(ChatGenerator)
@@ -483,7 +522,9 @@ class TestChatGenerator:
             (),
             {
                 "is_vlm_model": True,
-                "model": type("Wrapped", (), {"model": object(), "processor": object()})(),
+                "model": type(
+                    "Wrapped", (), {"model": object(), "processor": object()}
+                )(),
             },
         )()
         wrapper.tokenizer = None

--- a/tests/chat/mlx/test_wrapper_cache.py
+++ b/tests/chat/mlx/test_wrapper_cache.py
@@ -10,7 +10,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from mlx_omni_server.chat.mlx.wrapper_cache import MLXWrapperCache, WrapperCacheKey
+from mlx_omni_server.chat.mlx.wrapper_cache import (
+    MLXWrapperCache,
+    WrapperCacheKey,
+    get_model_cache_config_from_env,
+)
 
 
 class MockChatGenerator:
@@ -22,6 +26,30 @@ class MockChatGenerator:
 
     def __str__(self):
         return f"MockWrapper({self.model_id})"
+
+
+class TestWrapperCacheConfig:
+    """Test wrapper cache configuration parsing."""
+
+    def test_env_config_defaults(self):
+        """Missing environment variables should use conservative defaults."""
+        assert get_model_cache_config_from_env({}) == (1, 300)
+
+    def test_env_config_values(self):
+        """Environment variables should be parsed as integers."""
+        environ = {
+            "MLX_OMNI_MODEL_CACHE_SIZE": "2",
+            "MLX_OMNI_MODEL_CACHE_TTL": "60",
+        }
+        assert get_model_cache_config_from_env(environ) == (2, 60)
+
+    def test_env_config_rejects_invalid_values(self):
+        """Invalid environment values should fail early."""
+        with pytest.raises(ValueError, match="MLX_OMNI_MODEL_CACHE_SIZE"):
+            get_model_cache_config_from_env({"MLX_OMNI_MODEL_CACHE_SIZE": "bad"})
+
+        with pytest.raises(ValueError, match="MLX_OMNI_MODEL_CACHE_TTL"):
+            get_model_cache_config_from_env({"MLX_OMNI_MODEL_CACHE_TTL": "-1"})
 
 
 class TestWrapperCacheKey:
@@ -108,6 +136,43 @@ class TestMLXWrapperCache:
         assert "adapter" in updated_info["lru_order"][0]
 
     @patch("mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create")
+    def test_lru_eviction_releases_cache_reference(self, mock_create):
+        """LRU eviction should run best-effort memory cleanup."""
+        mock_create.side_effect = [
+            MockChatGenerator("model1"),
+            MockChatGenerator("model2"),
+        ]
+        cache = MLXWrapperCache(max_size=1, ttl_seconds=0)
+
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.clear_mlx_memory"
+        ) as cleanup:
+            cache.get_wrapper("model1")
+            cache.get_wrapper("model2")
+
+        cleanup.assert_called_once_with()
+
+    @patch("mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create")
+    def test_clear_cache_returns_count_and_releases_references(self, mock_create):
+        """clear_cache should clear cached entries and report how many were removed."""
+        mock_create.side_effect = [
+            MockChatGenerator("model1"),
+            MockChatGenerator("model2"),
+        ]
+
+        self.cache.get_wrapper("model1")
+        self.cache.get_wrapper("model2")
+
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.clear_mlx_memory"
+        ) as cleanup:
+            cleared_count = self.cache.clear_cache()
+
+        assert cleared_count == 2
+        cleanup.assert_called_once_with()
+        assert self.cache.get_cache_info()["cache_size"] == 0
+
+    @patch("mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create")
     def test_cache_management(self, mock_create):
         """Test cache size changes, clearing, and error handling."""
         mock_create.side_effect = [
@@ -151,6 +216,79 @@ class TestMLXWrapperCacheThreadSafety:
         time.sleep(0.01)  # Small delay to increase chance of race conditions
         self.creation_count += 1
         return MockChatGenerator(f"{model_id}_{self.creation_count}")
+
+    def test_concurrent_same_model_creates_once(self):
+        """Test concurrent requests for one key only create one wrapper."""
+        create_started = threading.Event()
+        release_create = threading.Event()
+        create_count = 0
+        create_count_lock = threading.Lock()
+
+        def slow_create(model_id, **kwargs):
+            nonlocal create_count
+            with create_count_lock:
+                create_count += 1
+            create_started.set()
+            assert release_create.wait(timeout=1)
+            return MockChatGenerator(model_id)
+
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create",
+            side_effect=slow_create,
+        ):
+            threads = [
+                threading.Thread(target=lambda: self.cache.get_wrapper("same_model"))
+                for _ in range(3)
+            ]
+            for thread in threads:
+                thread.start()
+
+            assert create_started.wait(timeout=1)
+            time.sleep(0.05)
+            release_create.set()
+
+            for thread in threads:
+                thread.join(timeout=1)
+                assert not thread.is_alive()
+
+        assert create_count == 1
+
+    def test_concurrent_different_models_do_not_create_in_parallel(self):
+        """Test different keys serialize ChatGenerator.create calls."""
+        active_creates = 0
+        max_active_creates = 0
+        create_count = 0
+        create_lock = threading.Lock()
+
+        def slow_create(model_id, **kwargs):
+            nonlocal active_creates, max_active_creates, create_count
+            with create_lock:
+                active_creates += 1
+                create_count += 1
+                max_active_creates = max(max_active_creates, active_creates)
+            time.sleep(0.05)
+            with create_lock:
+                active_creates -= 1
+            return MockChatGenerator(model_id)
+
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create",
+            side_effect=slow_create,
+        ):
+            threads = [
+                threading.Thread(
+                    target=lambda i=i: self.cache.get_wrapper(f"model_{i}")
+                )
+                for i in range(3)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=1)
+                assert not thread.is_alive()
+
+        assert create_count == 3
+        assert max_active_creates == 1
 
     def test_concurrent_access(self):
         """Test concurrent access for same and different cache keys."""
@@ -255,9 +393,11 @@ class TestMLXWrapperCacheTTL:
 
         # Test manual cleanup
         self.cache.get_wrapper("model1")
-        time.sleep(0.5)
         self.cache.get_wrapper("model2")
-        time.sleep(0.8)  # model1 should be expired
+        with self.cache._lock:
+            current_time = time.time()
+            self.cache._access_times[WrapperCacheKey("model1")] = current_time - 2
+            self.cache._access_times[WrapperCacheKey("model2")] = current_time
 
         evicted_count = self.cache.cleanup_expired_items()
         assert evicted_count == 1
@@ -266,7 +406,7 @@ class TestMLXWrapperCacheTTL:
         assert any("model2" in key for key in info["cached_keys"])
 
         # Test TTL + LRU interaction
-        ttl_lru_cache = MLXWrapperCache(max_size=2, ttl_seconds=0.5)
+        ttl_lru_cache = MLXWrapperCache(max_size=2, ttl_seconds=1)
         with patch(
             "mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create"
         ) as mock_ttl_lru:
@@ -276,7 +416,7 @@ class TestMLXWrapperCacheTTL:
             ttl_lru_cache.get_wrapper("model1")
             time.sleep(0.1)
             ttl_lru_cache.get_wrapper("model2")
-            time.sleep(0.6)  # Both should expire
+            time.sleep(1.1)  # Both should expire
             ttl_lru_cache.get_wrapper("model3")  # Should trigger cleanup
             info = ttl_lru_cache.get_cache_info()
             assert info["cache_size"] == 1
@@ -321,3 +461,24 @@ class TestMLXWrapperCacheEdgeCases:
         info = large_cache.get_cache_info()
         assert info["max_size"] == 1000
         assert info["cache_size"] == 0
+
+    def test_set_max_size_zero_evicts_existing_entries(self):
+        """Setting max_size=0 should clear cached entries without hanging."""
+        cache = MLXWrapperCache(max_size=2, ttl_seconds=0)
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.ChatGenerator.create"
+        ) as mock_create:
+            mock_create.side_effect = [
+                MockChatGenerator("model1"),
+                MockChatGenerator("model2"),
+            ]
+            cache.get_wrapper("model1")
+            cache.get_wrapper("model2")
+
+        with patch(
+            "mlx_omni_server.chat.mlx.wrapper_cache.clear_mlx_memory"
+        ) as cleanup:
+            cache.set_max_size(0)
+
+        assert cache.get_cache_info()["cache_size"] == 0
+        cleanup.assert_called_once_with()

--- a/tests/chat/openai/test_cache_router.py
+++ b/tests/chat/openai/test_cache_router.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mlx_omni_server.chat.openai import cache_router
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(cache_router.router)
+    return TestClient(app)
+
+
+def test_get_cache_returns_wrapper_cache_info():
+    client = _client()
+
+    with patch("mlx_omni_server.chat.openai.cache_router.wrapper_cache") as mock_cache:
+        mock_cache.get_cache_info.return_value = {
+            "cache_size": 1,
+            "max_size": 1,
+            "ttl_seconds": 300,
+            "cached_keys": ["model1"],
+            "lru_order": ["model1"],
+            "ttl_info": [],
+        }
+
+        response = client.get("/v1/cache")
+
+    assert response.status_code == 200
+    assert response.json()["cache_size"] == 1
+    mock_cache.get_cache_info.assert_called_once_with()
+
+
+def test_clear_cache_calls_wrapper_cache_clear_cache():
+    client = _client()
+
+    with patch("mlx_omni_server.chat.openai.cache_router.wrapper_cache") as mock_cache:
+        mock_cache.clear_cache.return_value = 2
+        mock_cache.get_cache_info.return_value = {
+            "cache_size": 0,
+            "max_size": 1,
+            "ttl_seconds": 300,
+            "cached_keys": [],
+            "lru_order": [],
+            "ttl_info": [],
+        }
+
+        response = client.post("/v1/cache/clear")
+
+    assert response.status_code == 200
+    assert response.json()["cleared_count"] == 2
+    assert response.json()["cache_info"]["cache_size"] == 0
+    mock_cache.clear_cache.assert_called_once_with()

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -1,0 +1,104 @@
+"""Tests for server startup configuration."""
+
+from unittest.mock import patch
+
+from mlx_omni_server import main
+
+
+def test_default_model_cache_args_are_conservative(monkeypatch):
+    """Default cache settings should favor lower memory usage."""
+    monkeypatch.delenv("MLX_OMNI_MODEL_CACHE_SIZE", raising=False)
+    monkeypatch.delenv("MLX_OMNI_MODEL_CACHE_TTL", raising=False)
+
+    args = main.build_parser().parse_args([])
+
+    assert args.model_cache_size == 1
+    assert args.model_cache_ttl == 300
+
+
+def test_model_cache_args_use_environment(monkeypatch):
+    """Environment variables should configure parser defaults."""
+    monkeypatch.setenv("MLX_OMNI_MODEL_CACHE_SIZE", "2")
+    monkeypatch.setenv("MLX_OMNI_MODEL_CACHE_TTL", "60")
+
+    args = main.build_parser().parse_args([])
+
+    assert args.model_cache_size == 2
+    assert args.model_cache_ttl == 60
+
+
+def test_cli_model_cache_args_override_environment(monkeypatch):
+    """CLI arguments should override environment-based defaults."""
+    monkeypatch.setenv("MLX_OMNI_MODEL_CACHE_SIZE", "2")
+    monkeypatch.setenv("MLX_OMNI_MODEL_CACHE_TTL", "60")
+
+    args = main.build_parser().parse_args(
+        ["--model-cache-size", "4", "--model-cache-ttl", "120"]
+    )
+
+    assert args.model_cache_size == 4
+    assert args.model_cache_ttl == 120
+
+
+def test_start_configures_wrapper_cache_from_cli(monkeypatch):
+    """Server startup should apply parsed cache settings before uvicorn starts."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "mlx-omni-server",
+            "--model-cache-size",
+            "5",
+            "--model-cache-ttl",
+            "180",
+        ],
+    )
+
+    with (
+        patch.object(main.wrapper_cache, "configure") as mock_configure,
+        patch.object(main.uvicorn, "run") as mock_run,
+    ):
+        main.start()
+
+    mock_configure.assert_called_once_with(5, 180)
+    mock_run.assert_called_once()
+
+
+def test_start_exports_cache_config_for_workers(monkeypatch):
+    """CLI cache settings should be exported so worker processes inherit them."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "mlx-omni-server",
+            "--model-cache-size",
+            "6",
+            "--model-cache-ttl",
+            "90",
+        ],
+    )
+
+    with (
+        patch.object(main.wrapper_cache, "configure"),
+        patch.object(main.uvicorn, "run"),
+    ):
+        main.start()
+
+    assert main.os.environ["MLX_OMNI_MODEL_CACHE_SIZE"] == "6"
+    assert main.os.environ["MLX_OMNI_MODEL_CACHE_TTL"] == "90"
+
+
+def test_start_warns_when_workers_greater_than_one(monkeypatch, caplog):
+    """Multiple worker processes should warn about multiplied model memory."""
+    monkeypatch.setattr("sys.argv", ["mlx-omni-server", "--workers", "2"])
+
+    with (
+        patch.object(main.wrapper_cache, "configure"),
+        patch.object(main.uvicorn, "run") as mock_run,
+        caplog.at_level("WARNING"),
+    ):
+        main.start()
+
+    mock_run.assert_called_once()
+    assert (
+        "Each worker process maintains its own independent model cache" in caplog.text
+    )
+    assert "memory usage may scale up to the worker count" in caplog.text


### PR DESCRIPTION
## Summary

- Use conservative default ChatGenerator cache settings and make cache size/TTL configurable via CLI/env.
- Serialize model loading and release cache-owned references on eviction/clear to reduce peak memory pressure.
- Add `/v1/cache` and `/v1/cache/clear` for cache inspection and manual cleanup.
- Warn when running multiple workers because each worker maintains an independent model cache.
- Preserve streamed reasoning in final generation results for thinking + tools / structured output paths.

Addresses #75
Refs #30
Refs #59

## Test plan

- `uv run pytest tests/chat/mlx tests/chat/openai/test_cache_router.py tests/test_main_config.py`
- `uv run black --check src/mlx_omni_server/chat/mlx/chat_generator.py src/mlx_omni_server/chat/mlx/wrapper_cache.py src/mlx_omni_server/main.py src/mlx_omni_server/routers.py src/mlx_omni_server/chat/openai/cache_router.py tests/chat/mlx/test_chat_generator.py tests/chat/mlx/test_wrapper_cache.py tests/chat/openai/test_cache_router.py tests/test_main_config.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cache management API endpoints: `GET /v1/cache` to view cache status and `POST /v1/cache/clear` to clear cached models.
  * Added CLI options `--model-cache-size` and `--model-cache-ttl` to configure model caching behavior at server startup.

* **Refactor**
  * Improved model caching with environment-based configuration and more efficient memory management.
  * Enhanced chat generation to better handle streamed reasoning and content merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->