### PR TITLE
adds tighter claude-code integration for qwen3 models.

### DIFF
--- a/src/mlx_omni_server/chat/anthropic/anthropic_messages_adapter.py
+++ b/src/mlx_omni_server/chat/anthropic/anthropic_messages_adapter.py
@@ -4,10 +4,14 @@ This module provides an adapter to convert between Anthropic Messages API format
 and the internal MLX generation interface.
 """
 
+import json
+import os
+import re
 import uuid
 from typing import Any, Dict, Generator, List, Optional
 
 from mlx_omni_server.chat.anthropic.anthropic_schema import (
+    RequestThinkingBlock,
     AnthropicTool,
     ContentBlock,
     InputMessage,
@@ -87,9 +91,14 @@ class AnthropicMessagesAdapter:
                 content_parts = []
                 for block in msg.content:
                     if isinstance(block, RequestTextBlock):
-                        content_parts.append(block.text)
+                        # Strip tool call XML that leaked into text content
+                        clean = re.sub(r"<tool_call>.*?</tool_call>", "", block.text, flags=re.DOTALL).strip()
+                        clean = re.sub(r"<function=.*?</tool_call>", "", clean, flags=re.DOTALL).strip()
+                        if clean:
+                            content_parts.append(clean)
                     elif isinstance(block, RequestToolUseBlock):
                         # Handle tool use blocks
+                        logger.debug(f"tool_use block: id={block.id} name={block.name} input={block.input}")
                         mlx_msg["tool_calls"] = [
                             {
                                 "id": block.id,
@@ -114,6 +123,8 @@ class AnthropicMessagesAdapter:
                         mlx_msg["tool_call_id"] = block.tool_use_id
                         if block.is_error:
                             mlx_msg["name"] = "error"
+                    elif isinstance(block, RequestThinkingBlock):
+                        pass  # Thinking blocks are not passed to the model
                     # Note: Image blocks would be handled here too
 
                 if content_parts:
@@ -180,9 +191,11 @@ class AnthropicMessagesAdapter:
 
         # Prepare sampler configuration
         sampler_config = {
-            "temp": request.temperature or 1.0,
-            "top_p": request.top_p or 1.0,
-            "top_k": request.top_k or 0,
+            "temp": request.temperature or float(os.environ.get("MLX_OMNI_TEMPERATURE", 1.0)),
+            "top_p": request.top_p or float(os.environ.get("MLX_OMNI_TOP_P", 1.0)),
+            "top_k": request.top_k or int(os.environ.get("MLX_OMNI_TOP_K", 0)),
+            **({"min_p": getattr(request, "min_p", None) if getattr(request, "min_p", None) is not None else float(os.environ.get("MLX_OMNI_MIN_P") or 0)} if (getattr(request, "min_p", None) is not None or os.environ.get("MLX_OMNI_MIN_P")) else {}),
+            **({"repetition_penalty": getattr(request, "repetition_penalty", None) or float(os.environ.get("MLX_OMNI_REPETITION_PENALTY") or 1.0)} if (getattr(request, "repetition_penalty", None) is not None or os.environ.get("MLX_OMNI_REPETITION_PENALTY")) else {}),
         }
 
         logger.info(f"Anthropic messages: {messages}")
@@ -191,7 +204,8 @@ class AnthropicMessagesAdapter:
         params = {
             "messages": messages,
             "tools": tools,
-            "max_tokens": request.max_tokens,
+            "max_tokens": int(os.environ.get("MLX_OMNI_MAX_TOKENS") or request.max_tokens),
+            **({"max_kv_size": int(os.environ.get("MLX_OMNI_CONTEXT_SIZE"))} if os.environ.get("MLX_OMNI_CONTEXT_SIZE") else {}),
             "sampler": sampler_config,
             "template_kwargs": template_kwargs,
             "enable_prompt_cache": True,
@@ -288,8 +302,14 @@ class AnthropicMessagesAdapter:
             result = self._generate_wrapper.generate(**params)
 
             # Create content blocks
+            logger.debug(f"generate result text: {result.content.text[:300]!r}")
+            logger.debug(f"generate result tool_calls: {result.content.tool_calls}")
+            logger.debug(f"generate finish_reason: {result.finish_reason}")
+            # Strip tool call XML from text so it does not leak into the text block
+            clean_text = re.sub(r"<tool_call>.*?</tool_call>", "", result.content.text, flags=re.DOTALL).strip()
+            clean_text = re.sub(r"<function=.*?</tool_call>", "", clean_text, flags=re.DOTALL).strip()
             content_blocks = self._create_content_blocks(
-                text_content=result.content.text,
+                text_content=clean_text or None,
                 reasoning_content=result.content.reasoning,
                 tool_calls=result.content.tool_calls,
             )
@@ -357,6 +377,8 @@ class AnthropicMessagesAdapter:
             current_block_index = 0
             in_thinking = False
 
+            accumulated_text = []
+            in_text_block = False
             for chunk in self._generate_wrapper.generate_stream(**params):
                 # Determine content type and send appropriate events
                 if chunk.content.reasoning_delta:
@@ -382,7 +404,7 @@ class AnthropicMessagesAdapter:
                     accumulated_reasoning += chunk.content.reasoning_delta
 
                 elif chunk.content.text_delta:
-                    # Text content
+                    # Smart streaming: emit text until tool_call tag starts, then buffer
                     if in_thinking:
                         # End thinking block
                         yield MessageStreamEvent(
@@ -391,30 +413,43 @@ class AnthropicMessagesAdapter:
                         )
                         current_block_index += 1
                         in_thinking = False
-
-                        # Start text block
-                        yield MessageStreamEvent(
-                            type=StreamEventType.CONTENT_BLOCK_START,
-                            index=current_block_index,
-                            content_block=TextBlock(text=""),
-                        )
-                    elif not accumulated_text:
-                        # First text chunk - start text block
-                        yield MessageStreamEvent(
-                            type=StreamEventType.CONTENT_BLOCK_START,
-                            index=current_block_index,
-                            content_block=TextBlock(text=""),
-                        )
-
-                    # Text delta
-                    yield MessageStreamEvent(
-                        type=StreamEventType.CONTENT_BLOCK_DELTA,
-                        index=current_block_index,
-                        delta=StreamDelta(
-                            type="text_delta", text=chunk.content.text_delta
-                        ),
-                    )
                     accumulated_text += chunk.content.text_delta
+                    full_so_far = "".join(accumulated_text)
+                    # Suppress streaming once we see a tool_call opening tag
+                    tool_call_start = full_so_far.find("<tool_call>")
+                    if tool_call_start == -1:
+                        # No tool call yet - stream this chunk normally
+                        if not in_text_block:
+                            yield MessageStreamEvent(
+                                type=StreamEventType.CONTENT_BLOCK_START,
+                                index=current_block_index,
+                                content_block=TextBlock(text=""),
+                            )
+                            in_text_block = True
+                        yield MessageStreamEvent(
+                            type=StreamEventType.CONTENT_BLOCK_DELTA,
+                            index=current_block_index,
+                            delta=StreamDelta(
+                                type="text_delta", text=chunk.content.text_delta
+                            ),
+                        )
+                    elif tool_call_start > 0 and not in_text_block:
+                        # Tool call starts mid-chunk - emit text before it
+                        pre_text = full_so_far[:tool_call_start]
+                        if pre_text.strip():
+                            yield MessageStreamEvent(
+                                type=StreamEventType.CONTENT_BLOCK_START,
+                                index=current_block_index,
+                                content_block=TextBlock(text=""),
+                            )
+                            in_text_block = True
+                            yield MessageStreamEvent(
+                                type=StreamEventType.CONTENT_BLOCK_DELTA,
+                                index=current_block_index,
+                                delta=StreamDelta(type="text_delta", text=pre_text),
+                            )
+                    # else: tool call already started, just accumulate
+
 
                 final_result = chunk
 
@@ -429,12 +464,64 @@ class AnthropicMessagesAdapter:
                     ),
                 )
 
-            # End final content block
-            yield MessageStreamEvent(
-                type=StreamEventType.CONTENT_BLOCK_STOP, index=current_block_index
-            )
 
             # Map stop reason and usage
+            # Parse tool calls from accumulated text
+            full_text = "".join(accumulated_text)
+            logger.debug(f"stream full text: {repr(full_text)[:500]}")
+            parsed_tool_calls = None
+            if hasattr(self._generate_wrapper, "chat_template") and self._generate_wrapper.chat_template and hasattr(self._generate_wrapper.chat_template, "tools_parser"):
+                parser = self._generate_wrapper.chat_template.tools_parser
+                if parser:
+                    parsed_tool_calls = parser.parse_tools(full_text)
+            logger.debug(f"stream parsed tool_calls: {parsed_tool_calls}")
+
+            # Emit buffered text block only if there is clean non-tool-call text
+            clean_text = re.sub(r"<tool_call>.*?</tool_call>", "", full_text, flags=re.DOTALL).strip()
+            clean_text = re.sub(r"<function=.*?</tool_call>", "", clean_text, flags=re.DOTALL).strip()
+            if clean_text and not parsed_tool_calls:
+                yield MessageStreamEvent(
+                    type=StreamEventType.CONTENT_BLOCK_START,
+                    index=current_block_index,
+                    content_block=TextBlock(text=""),
+                )
+                yield MessageStreamEvent(
+                    type=StreamEventType.CONTENT_BLOCK_DELTA,
+                    index=current_block_index,
+                    delta=StreamDelta(type="text_delta", text=clean_text),
+                )
+                yield MessageStreamEvent(
+                    type=StreamEventType.CONTENT_BLOCK_STOP,
+                    index=current_block_index,
+                )
+                current_block_index += 1
+
+            # Emit tool use blocks after text block is closed
+            if parsed_tool_calls:
+                for tool_call in parsed_tool_calls:
+                    current_block_index += 1
+                    yield MessageStreamEvent(
+                        type=StreamEventType.CONTENT_BLOCK_START,
+                        index=current_block_index,
+                        content_block=ToolUseBlock(
+                            id=tool_call.id,
+                            name=tool_call.name,
+                            input={},
+                        ),
+                    )
+                    yield MessageStreamEvent(
+                        type=StreamEventType.CONTENT_BLOCK_DELTA,
+                        index=current_block_index,
+                        delta=StreamDelta(
+                            type="input_json_delta",
+                            partial_json=json.dumps(tool_call.arguments),
+                        ),
+                    )
+                    yield MessageStreamEvent(
+                        type=StreamEventType.CONTENT_BLOCK_STOP,
+                        index=current_block_index,
+                    )
+
             if final_result:
                 cached_tokens = final_result.stats.cache_hit_tokens
                 usage = Usage(
@@ -444,10 +531,9 @@ class AnthropicMessagesAdapter:
                         cached_tokens if cached_tokens > 0 else None
                     ),
                 )
-
                 stop_reason = self._map_finish_reason(
                     final_result.finish_reason,
-                    False,  # StreamContent doesn't have tool_calls, so always False
+                    bool(parsed_tool_calls),
                 )
             else:
                 usage = Usage(input_tokens=0, output_tokens=0)

--- a/src/mlx_omni_server/chat/anthropic/anthropic_schema.py
+++ b/src/mlx_omni_server/chat/anthropic/anthropic_schema.py
@@ -145,11 +145,27 @@ class ThinkingConfigDisabled(BaseModel):
     type: Literal["disabled"] = "disabled"
 
 
-ThinkingConfig = Union[ThinkingConfigEnabled, ThinkingConfigDisabled]
+
+
+class ThinkingConfigAdaptive(BaseModel):
+    """Adaptive thinking configuration (Claude Code sends type='adaptive')."""
+    model_config = {"extra": "allow"}
+    type: Literal["adaptive"] = "adaptive"
+    budget_tokens: Optional[int] = None
+
+ThinkingConfig = Union[ThinkingConfigEnabled, ThinkingConfigDisabled, ThinkingConfigAdaptive]
 
 
 # Request Messages
+class RequestThinkingBlock(BaseModel):
+    model_config = {"extra": "allow"}
+    type: Literal["thinking"] = "thinking"
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
+
+
 class RequestTextBlock(BaseModel):
+    model_config = {"extra": "allow"}
     """Text block in request."""
 
     type: Literal["text"] = "text"
@@ -157,6 +173,7 @@ class RequestTextBlock(BaseModel):
 
 
 class RequestImageBlock(BaseModel):
+    model_config = {"extra": "allow"}
     """Image block in request (base64 format)."""
 
     type: Literal["image"] = "image"
@@ -164,6 +181,7 @@ class RequestImageBlock(BaseModel):
 
 
 class RequestToolUseBlock(BaseModel):
+    model_config = {"extra": "allow"}
     """Tool use block in request."""
 
     type: Literal["tool_use"] = "tool_use"
@@ -173,6 +191,7 @@ class RequestToolUseBlock(BaseModel):
 
 
 class RequestToolResultBlock(BaseModel):
+    model_config = {"extra": "allow"}
     """Tool result block in request."""
 
     type: Literal["tool_result"] = "tool_result"
@@ -182,7 +201,7 @@ class RequestToolResultBlock(BaseModel):
 
 
 RequestContentBlock = Union[
-    RequestTextBlock, RequestImageBlock, RequestToolUseBlock, RequestToolResultBlock
+    RequestTextBlock, RequestThinkingBlock, RequestImageBlock, RequestToolUseBlock, RequestToolResultBlock
 ]
 
 
@@ -195,6 +214,7 @@ class InputMessage(BaseModel):
 
 # System Prompt
 class SystemTextBlock(BaseModel):
+    model_config = {"extra": "allow"}
     """System text block."""
 
     type: Literal["text"] = "text"
@@ -236,6 +256,8 @@ class MessagesRequest(BaseModel):
     top_p: Optional[float] = Field(None, ge=0, le=1)
     top_k: Optional[int] = Field(None, ge=0)
     stop_sequences: Optional[List[str]] = None
+    min_p: Optional[float] = Field(None, ge=0, le=1)
+    repetition_penalty: Optional[float] = Field(None, ge=0)
     stream: Optional[bool] = False
     tools: Optional[List[AnthropicTool]] = None
     tool_choice: Optional[ToolChoice] = None

--- a/src/mlx_omni_server/chat/anthropic/router.py
+++ b/src/mlx_omni_server/chat/anthropic/router.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Generator, Optional
 
 from fastapi import APIRouter, Query
@@ -63,8 +64,9 @@ async def list_anthropic_models(
 async def create_message(request: MessagesRequest):
     """Create an Anthropic Messages API completion"""
 
+    model_id = os.environ.get("MLX_OMNI_MODEL") or request.model
     anthropic_model = _create_anthropic_model(
-        request.model,
+        model_id,
         # Extract extra params if needed - for now use defaults
         None,  # adapter_path
         None,  # draft_model

--- a/src/mlx_omni_server/chat/mlx/tools/base_tools.py
+++ b/src/mlx_omni_server/chat/mlx/tools/base_tools.py
@@ -133,7 +133,7 @@ def extract_tools(text: str) -> Optional[List[ToolCall]]:
     # If the model attempted a <tool_call> but we couldn't parse it, do NOT fall back
     # to shallow regex parsing (it can produce empty args {} and trigger tool-error loops).
     if saw_tool_call_block:
-        logger.warning(
+        logger.debug(
             "Detected <tool_call> block(s) but failed to parse; returning no tool calls"
         )
         return None


### PR DESCRIPTION
Claude Code compatibility fixes for Anthropic API endpoint

anthropic_schema.py: Add model_config = {"extra": "allow"} to all request-side content block models (RequestTextBlock, RequestImageBlock, RequestToolUseBlock, RequestToolResultBlock, SystemTextBlock) to tolerate cache_control fields sent by Claude Code's beta prompt caching
anthropic_schema.py: Add ThinkingConfigAdaptive for Claude Code's "type": "adaptive" thinking mode
anthropic_schema.py: Add RequestThinkingBlock to handle thinking blocks in multi-turn message history
anthropic_schema.py: Add min_p and repetition_penalty fields to MessagesRequest
router.py: Add MLX_OMNI_MODEL env var to override the model name in requests (Claude Code sends its own model string which is not a valid HuggingFace repo id)
router.py: Add MLX_OMNI_MAX_TOKENS and MLX_OMNI_CONTEXT_SIZE env vars
anthropic_messages_adapter.py: Add MLX_OMNI_TEMPERATURE, MLX_OMNI_TOP_P, MLX_OMNI_TOP_K, MLX_OMNI_MIN_P, MLX_OMNI_REPETITION_PENALTY env vars for sampling defaults
anthropic_messages_adapter.py: Fix streaming path to parse tool calls from accumulated text and emit proper CONTENT_BLOCK_START/DELTA/STOP events with input_json_delta for tool arguments
anthropic_messages_adapter.py: Suppress tool call XML from streamed text while preserving pre-tool-call text streaming for syntax highlighting
base_tools.py: Downgrade false-positive WARNING to DEBUG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive thinking configuration support
  * Introduced `min_p` and `repetition_penalty` generation parameters

* **Bug Fixes**
  * Improved handling of tool call XML in model responses
  * Enhanced tool call parsing and emission in streaming mode

* **Improvements**
  * Model selection now respects `MLX_OMNI_MODEL` environment variable
  * Generation parameters now support environment variable fallbacks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/madroidmaq/mlx-omni-server/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->